### PR TITLE
Fixes the account name with shell variable USER

### DIFF
--- a/mam4_refactor_scripts/setup_baselines_and_comparison.sh
+++ b/mam4_refactor_scripts/setup_baselines_and_comparison.sh
@@ -26,7 +26,7 @@ main() {
     compiler="intel"
 
     #scratch directory path
-    scratch_dir="/compyfs/sing201/e3sm_scratch"
+    scratch_dir="/compyfs/$USER/e3sm_scratch"
 
     #baseline directory path
     baseline_dir="/compyfs/e3sm_baselines/$compiler"


### PR DESCRIPTION
Accidentally used my account name in the script. Fixed it with the variable "USER" so that it woks for all.