### PR TITLE
Modifies all tests to use PG2 grid

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -72,10 +72,11 @@ _TESTS = {
 
     "eagles_mam" : {
         "tests"   : (
-            "SMS_D.ne4_oQU240.F2010",
-            "ERS.ne4_oQU240.F2010",
-            "PET.ne4_oQU240.F2010",
-            "PEM.ne4_oQU240.F2010"
+            "SMS_D.ne4pg2_oQU480.F2010",
+            "SMS_D_Ln5_P32x1.ne4pg2_oQU480.F2010",
+            "ERS.ne4pg2_oQU480.F2010",
+            "PET.ne4pg2_oQU480.F2010",
+            "PEM_P64x1.ne4pg2_oQU480.F2010"
             )
         },
 

--- a/mam4_refactor_scripts/setup_baselines_and_comparison.sh
+++ b/mam4_refactor_scripts/setup_baselines_and_comparison.sh
@@ -32,14 +32,14 @@ main() {
     baseline_dir="/compyfs/e3sm_baselines/$compiler"
 
     test_name="SMS_D_Ln5_P32x1"
-    grid="ne4_oQU240"
+    grid="ne4pg2_oQU480"
     compset="F2010"
     project="esmd"
 
     #test_id for the test is obtained from the command line arg
 
     #baseline test_id (must be different from the test_id above; you can simply add "base_" infront of test_id if you like)
-    baseline_test_id="base_"$test_id
+    baseline_test_id="base_$USER"$test_id
 
     #Test_Id for the comparison simulation(must be different from the test_ids above; you can simply add "comp_" infront of test_id if you like)
     comparison_test_id="comp_"$test_id

--- a/mam4_refactor_scripts/setup_baselines_and_comparison.sh
+++ b/mam4_refactor_scripts/setup_baselines_and_comparison.sh
@@ -39,7 +39,7 @@ main() {
     #test_id for the test is obtained from the command line arg
 
     #baseline test_id (must be different from the test_id above; you can simply add "base_" infront of test_id if you like)
-    baseline_test_id="base_$USER"$test_id
+    baseline_test_id="base_${USER}_"$test_id
 
     #Test_Id for the comparison simulation(must be different from the test_ids above; you can simply add "comp_" infront of test_id if you like)
     comparison_test_id="comp_"$test_id


### PR DESCRIPTION
PG2 grid are faster than np4 grid as they have less columns. This PR modifies tests in the mam4 testing suite as well as the auto refactor test generation script. The baselines for the starting point of the code are stored at:
/compyfs/e3sm_baselines/intel/mam4_org_v2_baselines/

We can use these baseline to compare against the refactored code.