### PR TITLE
Refactor subroutine hf in nucleate_ice.F90

### DIFF
--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -467,8 +467,11 @@ subroutine hf(Temperature, w_vlc, RH, Na, Ni)
 ! Liu & Penner (2005), Meteorol. Z.
 !-------------------------------------------------------------------------------
 
-      real(r8), intent(in)  :: Temperature, w_vlc, RH, Na
-      real(r8), intent(out) :: Ni
+      real(r8), intent(in)  :: Temperature     ! [C] temperature
+      real(r8), intent(in)  :: w_vlc           ! [m/s] vertical velocity
+      real(r8), intent(in)  :: RH              ! unitless relative humidity
+      real(r8), intent(in)  :: Na              ! [#/cm^3] aerosol number concentrations 
+      real(r8), intent(out) :: Ni              ! [#/cm^3] ice number concentrations
 
 !---------------------------------------------------------------------
 ! parameters
@@ -539,8 +542,9 @@ subroutine calculate_RHw_hf(Temperature, lnw, RHw)
 ! Eq. 3.1 in Liu & Penner (2005), Meteorol. Z.
 !-------------------------------------------------------------------------------
 
-   real(r8), intent(in)  :: Temperature, lnw
-   real(r8), intent(out) :: RHw
+   real(r8), intent(in)  :: Temperature     ! [C] temperature
+   real(r8), intent(in)  :: lnw             ! ln of vertical velocity
+   real(r8), intent(out) :: RHw             ! relative humidity threshold 
 
    real(r8) A_coef, B_coef, C_coef
  
@@ -560,10 +564,12 @@ subroutine calculate_Ni_hf(A1, B1, C1, A2, B2, C2, Temperature, lnw, Na, Ni)
 ! Eq. 3.3 in Liu & Penner (2005), Meteorol. Z.
 !-------------------------------------------------------------------------------
 
-   real(r8), intent(in)  :: A1, B1, C1
-   real(r8), intent(in)  :: A2, B2, C2
-   real(r8), intent(in)  :: Temperature, lnw, Na
-   real(r8), intent(out) :: Ni
+   real(r8), intent(in)  :: A1, B1, C1     ! Coefficients        
+   real(r8), intent(in)  :: A2, B2, C2     ! Coefficients
+   real(r8), intent(in)  :: Temperature    ! [C] temperature
+   real(r8), intent(in)  :: lnw            ! ln of vertical velocity
+   real(r8), intent(in)  :: Na             ! [#/cm3] aerosol number concentrations
+   real(r8), intent(out) :: Ni             ! [#/cm3] ice number concentrations
    
    real(r8) k1, k2
 

--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -467,11 +467,11 @@ subroutine hf(Temperature, w_vlc, RH, Na, Ni)
 ! Liu & Penner (2005), Meteorol. Z.
 !-------------------------------------------------------------------------------
 
-      real(r8), intent(in)  :: Temperature     ! [C] temperature
-      real(r8), intent(in)  :: w_vlc           ! [m/s] vertical velocity
+      real(r8), intent(in)  :: Temperature     ! temperature [C]
+      real(r8), intent(in)  :: w_vlc           ! vertical velocity [m/s]
       real(r8), intent(in)  :: RH              ! unitless relative humidity
-      real(r8), intent(in)  :: Na              ! [#/cm^3] aerosol number concentrations 
-      real(r8), intent(out) :: Ni              ! [#/cm^3] ice number concentrations
+      real(r8), intent(in)  :: Na              ! aerosol number concentrations [#/cm^3]
+      real(r8), intent(out) :: Ni              ! ice number concentrations [#/cm^3]
 
 !---------------------------------------------------------------------
 ! parameters
@@ -542,7 +542,7 @@ subroutine calculate_RHw_hf(Temperature, lnw, RHw)
 ! Eq. 3.1 in Liu & Penner (2005), Meteorol. Z.
 !-------------------------------------------------------------------------------
 
-   real(r8), intent(in)  :: Temperature     ! [C] temperature
+   real(r8), intent(in)  :: Temperature     ! temperature [C]
    real(r8), intent(in)  :: lnw             ! ln of vertical velocity
    real(r8), intent(out) :: RHw             ! relative humidity threshold 
 
@@ -566,10 +566,10 @@ subroutine calculate_Ni_hf(A1, B1, C1, A2, B2, C2, Temperature, lnw, Na, Ni)
 
    real(r8), intent(in)  :: A1, B1, C1     ! Coefficients        
    real(r8), intent(in)  :: A2, B2, C2     ! Coefficients
-   real(r8), intent(in)  :: Temperature    ! [C] temperature
+   real(r8), intent(in)  :: Temperature    ! temperature [C]
    real(r8), intent(in)  :: lnw            ! ln of vertical velocity
-   real(r8), intent(in)  :: Na             ! [#/cm3] aerosol number concentrations
-   real(r8), intent(out) :: Ni             ! [#/cm3] ice number concentrations
+   real(r8), intent(in)  :: Na             ! aerosol number concentrations [#/cm^3]
+   real(r8), intent(out) :: Ni             ! ice number concentrations [#/cm^3]
    
    real(r8) k1, k2
 


### PR DESCRIPTION
This PR refactored subroutine hf in nucleate_ice.F90. Two additional subroutines are introduced to calculate RHw and Ni. The SMS test show BFB answers. 
