### PR TITLE
Refactor subroutine explmix in ndrop.F90

### DIFF
--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -1208,10 +1208,7 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
                ekkm(k)*(overlapm(k)*qold(km1)-qold(k)) )
          endif
          !        force to non-negative
-         !        if(q(k)<-1.e-30)then
-         !           write(iulog,*)'q=',q(k),' in explmix'
          q(k)=max(q(k),0._r8)
-         !        endif
       enddo
 
 end subroutine explmix

--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -1175,19 +1175,19 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
 
 
    integer, intent(in) :: pver ! number of levels
-   real(r8), intent(out) :: q(pver) ! [# or kg / kg] number / mass mixing ratio to be updated 
-   real(r8), intent(in) :: qold(pver) ! [# or kg / kg] number / mass mixing ratio from previous time step
-   real(r8), intent(in) :: src(pver) ! [# or kg / (kg-s)] source due to activation/nucleation
-   real(r8), intent(in) :: ekkp(pver) ! [/s] zn*zs*density*diffusivity (kg/m3 m2/s) at interface 
+   real(r8), intent(out) :: q(pver) ! number / mass mixing ratio to be updated [# or kg / kg] 
+   real(r8), intent(in) :: qold(pver) ! number / mass mixing ratio from previous time step [# or kg / kg] 
+   real(r8), intent(in) :: src(pver) ! source due to activation/nucleation [# or kg / (kg-s)]
+   real(r8), intent(in) :: ekkp(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface [/s]
    ! below layer k  (k,k+1 interface)
-   real(r8), intent(in) :: ekkm(pver) ! [/s] zn*zs*density*diffusivity (kg/m3 m2/s) at interface
+   real(r8), intent(in) :: ekkm(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface [/s]
    ! above layer k  (k,k+1 interface)
-   real(r8), intent(in) :: overlapp(pver) ! [fraction] cloud overlap below
-   real(r8), intent(in) :: overlapm(pver) ! [fraction] cloud overlap above
-   real(r8), intent(in) :: dt ! [s] time step 
+   real(r8), intent(in) :: overlapp(pver) ! cloud overlap below [fraction]
+   real(r8), intent(in) :: overlapm(pver) ! cloud overlap above [fraction]
+   real(r8), intent(in) :: dt ! time step [s] 
    logical, intent(in) :: is_unact ! true if this is an unactivated species
-   real(r8), intent(in),optional :: qactold(pver) 
-   ! [# or kg / kg] number / mass mixing ratio of ACTIVATED species from previous step
+   real(r8), intent(in),optional :: qactold(pver) ! [# or kg / kg] 
+   ! number / mass mixing ratio of ACTIVATED species from previous step
    ! *** this should only be present
    !     if the current species is unactivated number/sfc/mass
 
@@ -1207,6 +1207,7 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
             q(k) = qold(k) + dt*(src(k) + ekkp(k)*(overlapp(k)*qold(kp1)-qold(k)) +      &
                ekkm(k)*(overlapm(k)*qold(km1)-qold(k)) )
          endif
+
          !        force to non-negative
          q(k)=max(q(k),0._r8)
       enddo

--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -971,7 +971,8 @@ subroutine dropmixnuc( &
          end do
          call explmix(  &
             qcld, srcn, ekkp, ekkm, overlapp,  &
-            overlapm, qncld, zero, zero, pver, &
+!! BJG            overlapm, qncld, zero, zero, pver, &
+            overlapm, qncld, pver, &
             dtmix, .false.)
 
          ! rce-comment
@@ -995,12 +996,14 @@ subroutine dropmixnuc( &
 
             call explmix( &
                raercol_cw(:,mm,nnew), source, ekkp, ekkm, overlapp, &
-               overlapm, raercol_cw(:,mm,nsav), zero, zero, pver,   &
+!! BJG               overlapm, raercol_cw(:,mm,nsav), zero, zero, pver,   &
+               overlapm, raercol_cw(:,mm,nsav), pver,   &
                dtmix, .false.)
 
             call explmix( &
                raercol(:,mm,nnew), source, ekkp, ekkm, overlapp,  &
-               overlapm, raercol(:,mm,nsav), zero, flxconv, pver, &
+!! BJG               overlapm, raercol(:,mm,nsav), zero, flxconv, pver, &
+               overlapm, raercol(:,mm,nsav), pver, &
                dtmix, .true., raercol_cw(:,mm,nsav))
 
             do l = 1, nspec_amode(m)
@@ -1017,12 +1020,14 @@ subroutine dropmixnuc( &
 
                call explmix( &
                   raercol_cw(:,mm,nnew), source, ekkp, ekkm, overlapp, &
-                  overlapm, raercol_cw(:,mm,nsav), zero, zero, pver,   &
+!!                  overlapm, raercol_cw(:,mm,nsav), zero, zero, pver,   &  BJG
+                  overlapm, raercol_cw(:,mm,nsav), pver,   & 
                   dtmix, .false.)
 
                call explmix( &
                   raercol(:,mm,nnew), source, ekkp, ekkm, overlapp,  &
-                  overlapm, raercol(:,mm,nsav), zero, flxconv, pver, &
+!! BJG                 overlapm, raercol(:,mm,nsav), zero, flxconv, pver, &
+                  overlapm, raercol(:,mm,nsav), pver, &
                   dtmix, .true., raercol_cw(:,mm,nsav))
 
             end do
@@ -1168,24 +1173,27 @@ end subroutine dropmixnuc
 !===============================================================================
 
 subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
-   qold, surfrate, flxconv, pver, dt, is_unact, qactold )
+!!   qold, surfrate, flxconv, pver, dt, is_unact, qactold )  BJG 9/30
+   qold, pver, dt, is_unact, qactold ) 
 
    !  explicit integration of droplet/aerosol mixing
    !     with source due to activation/nucleation
 
 
    integer, intent(in) :: pver ! number of levels
-   real(r8), intent(out) :: q(pver) ! mixing ratio to be updated
-   real(r8), intent(in) :: qold(pver) ! mixing ratio from previous time step
-   real(r8), intent(in) :: src(pver) ! source due to activation/nucleation (/s)
+   real(r8), intent(out) :: q(pver) ! NUMBER / MASS mixing ratio to be updated  (# or kg / KG AIR)  BJG
+   real(r8), intent(in) :: qold(pver) ! NUMBER / MASS mixing ratio from previous time step (# or kg / KG AIR) BJG
+   real(r8), intent(in) :: src(pver) ! source due to activation/nucleation ( #/(kg air)/s or kg/(kg air)/s )
    real(r8), intent(in) :: ekkp(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface
    ! below layer k  (k,k+1 interface)
    real(r8), intent(in) :: ekkm(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface
    ! above layer k  (k,k+1 interface)
-   real(r8), intent(in) :: overlapp(pver) ! cloud overlap below
-   real(r8), intent(in) :: overlapm(pver) ! cloud overlap above
-   real(r8), intent(in) :: surfrate ! surface exchange rate (/s)
-   real(r8), intent(in) :: flxconv ! convergence of flux from surface
+   real(r8), intent(in) :: overlapp(pver) ! cloud overlap below (FRAC 0-1)
+   real(r8), intent(in) :: overlapm(pver) ! cloud overlap above (FRAC 0-1)
+!  BELOW IS ALWAYS ZERO, SO IT CAN BE REMOVED  BJG 9/30
+!!   real(r8), intent(in) :: surfrate ! surface exchange rate (/s)
+!  BELOW IS ALWAYS ZERO, SO IT CAN BE REMOVED  BJG 9/30
+!!   real(r8), intent(in) :: flxconv ! convergence of flux from surface  
    real(r8), intent(in) :: dt ! time step (s)
    logical, intent(in) :: is_unact ! true if this is an unactivated species
    real(r8), intent(in),optional :: qactold(pver)
@@ -1195,15 +1203,22 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
 
    integer k,kp1,km1
 
-   if ( is_unact ) then
+!! move if branch inside loop to simplify BJG 9/30   if ( is_unact ) then
       !     the qactold*(1-overlap) terms are resuspension of activated material
       do k=top_lev,pver
          kp1=min(k+1,pver)
          km1=max(k-1,top_lev)
-         q(k) = qold(k) + dt*( - src(k) + ekkp(k)*(qold(kp1) - qold(k) +       &
-            qactold(kp1)*(1.0_r8-overlapp(k)))               &
-            + ekkm(k)*(qold(km1) - qold(k) +     &
-            qactold(km1)*(1.0_r8-overlapm(k))) )
+
+
+         if ( is_unact ) then
+            q(k) = qold(k) + dt*( - src(k) + ekkp(k)*(qold(kp1) - qold(k) +       &
+               qactold(kp1)*(1.0_r8-overlapp(k)))               &
+               + ekkm(k)*(qold(km1) - qold(k) +     &
+               qactold(km1)*(1.0_r8-overlapm(k))) )
+         else
+            q(k) = qold(k) + dt*(src(k) + ekkp(k)*(overlapp(k)*qold(kp1)-qold(k)) +      &
+               ekkm(k)*(overlapm(k)*qold(km1)-qold(k)) )
+         endif
          !        force to non-negative
          !        if(q(k)<-1.e-30)then
          !           write(iulog,*)'q=',q(k),' in explmix'
@@ -1212,32 +1227,32 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
       end do
 
       !     diffusion loss at base of lowest layer
-      q(pver)=q(pver)-surfrate*qold(pver)*dt+flxconv*dt
+!!      q(pver)=q(pver)-surfrate*qold(pver)*dt+flxconv*dt   BJG 9/30
       !        force to non-negative
       !        if(q(pver)<-1.e-30)then
       !           write(iulog,*)'q=',q(pver),' in explmix'
       q(pver)=max(q(pver),0._r8)
       !        endif
-   else
-      do k=top_lev,pver
-         kp1=min(k+1,pver)
-         km1=max(k-1,top_lev)
-         q(k) = qold(k) + dt*(src(k) + ekkp(k)*(overlapp(k)*qold(kp1)-qold(k)) +      &
-            ekkm(k)*(overlapm(k)*qold(km1)-qold(k)) )
+!!   else
+!!      do k=top_lev,pver
+!!         kp1=min(k+1,pver)
+!!         km1=max(k-1,top_lev)
+!!   BJG      q(k) = qold(k) + dt*(src(k) + ekkp(k)*(overlapp(k)*qold(kp1)-qold(k)) +      &
+!!   BJG          ekkm(k)*(overlapm(k)*qold(km1)-qold(k)) )
          !        force to non-negative
          !        if(q(k)<-1.e-30)then
          !           write(iulog,*)'q=',q(k),' in explmix'
-         q(k)=max(q(k),0._r8)
+!!         q(k)=max(q(k),0._r8)
          !        endif
-      end do
+!!      end do
       !     diffusion loss at base of lowest layer
-      q(pver)=q(pver)-surfrate*qold(pver)*dt+flxconv*dt
+!!      q(pver)=q(pver)-surfrate*qold(pver)*dt+flxconv*dt BJG 9/30
       !        force to non-negative
       !        if(q(pver)<-1.e-30)then
       !           write(iulog,*)'q=',q(pver),' in explmix'
-      q(pver)=max(q(pver),0._r8)
+!!      q(pver)=max(q(pver),0._r8)
 
-   end if
+!!   end if
 
 end subroutine explmix
 

--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -969,7 +969,6 @@ subroutine dropmixnuc( &
                  + raercol_cw(pver,mm,nsav)*(nact(pver,m) - taumix_internal_pver_inv)
             srcn(pver) = srcn(pver) + max(0.0_r8,tmpa)
          end do
-!! BJG 10/3 remove two arguments of "zero" to explmix here and elsewhere, since have no impact on output.
          call explmix(  &
             qcld, srcn, ekkp, ekkm, overlapp,  &
             overlapm, qncld, pver, &
@@ -1176,30 +1175,28 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
 
 
    integer, intent(in) :: pver ! number of levels
-   real(r8), intent(out) :: q(pver) ! number / mass mixing ratio to be updated  (# or kg / (kg air))  
-   real(r8), intent(in) :: qold(pver) ! number / mass mixing ratio from previous time step (# or kg / (kg air)) 
-   real(r8), intent(in) :: src(pver) ! source due to activation/nucleation ( #/(kg air)/s or kg/(kg air)/s )  
-   real(r8), intent(in) :: ekkp(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface (overall units /s) 
+   real(r8), intent(out) :: q(pver) ! [# or kg / kg] number / mass mixing ratio to be updated 
+   real(r8), intent(in) :: qold(pver) ! [# or kg / kg] number / mass mixing ratio from previous time step
+   real(r8), intent(in) :: src(pver) ! [# or kg / (kg-s)] source due to activation/nucleation
+   real(r8), intent(in) :: ekkp(pver) ! [/s] zn*zs*density*diffusivity (kg/m3 m2/s) at interface 
    ! below layer k  (k,k+1 interface)
-   real(r8), intent(in) :: ekkm(pver) ! zn*zs*density*diffusivity (kg/m3 m2/s) at interface (overall units /s) 
+   real(r8), intent(in) :: ekkm(pver) ! [/s] zn*zs*density*diffusivity (kg/m3 m2/s) at interface
    ! above layer k  (k,k+1 interface)
-   real(r8), intent(in) :: overlapp(pver) ! cloud overlap below (fraction 0-1) 
-   real(r8), intent(in) :: overlapm(pver) ! cloud overlap above (fraction 0-1) 
-   real(r8), intent(in) :: dt ! time step (s)
+   real(r8), intent(in) :: overlapp(pver) ! [fraction] cloud overlap below
+   real(r8), intent(in) :: overlapm(pver) ! [fraction] cloud overlap above
+   real(r8), intent(in) :: dt ! [s] time step 
    logical, intent(in) :: is_unact ! true if this is an unactivated species
    real(r8), intent(in),optional :: qactold(pver) 
-   ! number / mass mixing ratio of ACTIVATED species from previous step (# or kg / (kg air)) 
+   ! [# or kg / kg] number / mass mixing ratio of ACTIVATED species from previous step
    ! *** this should only be present
    !     if the current species is unactivated number/sfc/mass
 
    integer k,kp1,km1
 
-!! move if branch inside k loop loop to simplify BJG 9/30   
       !     the qactold*(1-overlap) terms are resuspension of activated material
       do k=top_lev,pver
          kp1=min(k+1,pver)
          km1=max(k-1,top_lev)
-
 
          if ( is_unact ) then
             q(k) = qold(k) + dt*( - src(k) + ekkp(k)*(qold(kp1) - qold(k) +       &
@@ -1216,18 +1213,6 @@ subroutine explmix( q, src, ekkp, ekkm, overlapp, overlapm, &
          q(k)=max(q(k),0._r8)
          !        endif
       enddo
-
-      !     diffusion loss at base of lowest layer
-!!  Remove (commented out) line below, since surfrate and flxconv are always zero,
-!!  and also remove these as arguments to this subroutine 
-!!      q(pver)=q(pver)-surfrate*qold(pver)*dt+flxconv*dt   BJG 9/30
-      !        force to non-negative
-      !        if(q(pver)<-1.e-30)then
-      !           write(iulog,*)'q=',q(pver),' in explmix'
-!!  Remove (commented out) line below, since redundant with last pass of loop
-!!      q(pver)=max(q(pver),0._r8)  BJG 10/3
-      !        endif
-
 
 end subroutine explmix
 


### PR DESCRIPTION

Condense / restructure subroutine explmix in ndrop.F90, add units, and remove unneeded arguments (either explicitly zero or hardwired to zero (flxconv)).
