### PR TITLE
Remove unused code in nucleate_ice_cam.F90 and nucleate_ice.F90

### DIFF
--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -52,7 +52,6 @@ real(r8) :: mincld
 ! Subgrid scale factor on relative humidity (dimensionless)
 real(r8) :: subgrid
 
-real(r8), parameter :: Shet   = 1.3_r8     ! het freezing threshold
 real(r8), parameter :: rhoice = 0.5e3_r8   ! kg/m3, Wpice is not sensitive to rhoice 
 
 real(r8) :: ci
@@ -232,16 +231,10 @@ subroutine nucleati(  &
 
 
    ! deposition/condensation nucleation in mixed clouds (-37<T<0C) (Meyers, 1992)
-   if(tc.lt.0._r8 .and. tc.gt.-37._r8 .and. qc.gt.1.e-12_r8) then
-      esl = svp_water(tair)     ! over water in mixed clouds
-      esi = svp_ice(tair)     ! over ice
-      deles = (esl - esi)
-      nimey=1.e-3_r8*exp(12.96_r8*deles/esi - 0.639_r8)  
-   else
-      nimey=0._r8
-   endif
+   ! this part is executed but is always replaced by 0, because CNT scheme takes over
+   ! the calculation. use_hetfrz_classnuc is always true.
 
-   if (use_hetfrz_classnuc) nimey = 0._r8
+   nimey = 0._r8
 
    nuci=ni+nimey
    if(nuci.gt.9999._r8.or.nuci.lt.0._r8) then

--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -183,39 +183,6 @@ subroutine nucleati(  &
    wbar1 = wbar
    wbar2 = wbar
 
-   if (use_preexisting_ice) then
-
-      Ni_preice = ni_in*rhoair                    ! (convert from #/kg -> #/m3)
-      Ni_preice = Ni_preice / max(mincld,cldn)   ! in-cloud ice number density 
-
-!!== KZ_BUGFIX 
-      if (Ni_preice > 10.0_r8 .and. qi > 1.e-10_r8 ) then    ! > 0.01/L = 10/m3   
-!!== KZ_BUGFIX 
-         Shom = -1.5_r8   ! if Shom<1 , Shom will be recalculated in SUBROUTINE Vpreice, according to Ren & McKenzie, 2005
-         lami = (gamma4*ci*ni_in/qi)**(1._r8/3._r8)
-         Ri_preice = 0.5_r8/lami                  ! radius
-         Ri_preice = max(Ri_preice, 1e-8_r8)       ! >0.01micron
-         call Vpreice(pmid, tair, Ri_preice, Ni_preice, Shom, wpice)
-         call Vpreice(pmid, tair, Ri_preice, Ni_preice, Shet, wpicehet)
-      else
-         wpice    = 0.0_r8
-         wpicehet = 0.0_r8
-      endif
-
-      weff     = max(wbar-wpice, minweff)
-      wpice    = min(wpice, wbar)
-      weffhet  = max(wbar-wpicehet,minweff)
-      wpicehet = min(wpicehet, wbar)
-
-      wbar1 = weff
-      wbar2 = weffhet
-
-      detaT   = wbar/0.23_r8
-      RHimean = 1.0_r8
-      call frachom(tair, RHimean, detaT, fhom)
-
-   end if
-
    ni = 0._r8
    tc = tair - 273.15_r8
 
@@ -249,28 +216,12 @@ subroutine nucleati(  &
 
                   call hf(tc,wbar1,relhum,so4_num,nihf)
                   niimm=0._r8
-                  nidep=0._r8
-
-                  if (use_preexisting_ice) then
-                     if (nihf.gt.1e-3_r8) then ! hom occur,  add preexisting ice
-                        niimm=min(dst3_num,Ni_preice*1e-6_r8)       ! assuming dst_num freeze firstly
-                        nihf=nihf + Ni_preice*1e-6_r8 - niimm
-                     endif
-                     nihf=nihf*fhom
-                     n1=nihf+niimm 
-                  else
-                     n1=nihf
-                  end if
-
+                  nidep=0._r8   
+                  n1=nihf
+                  
                else
 
                   call hetero(tc,wbar2,soot_num+dst3_num,niimm,nidep)
-                  if (use_preexisting_ice) then
-                     if (niimm .gt. 1e-6_r8) then ! het freezing occur, add preexisting ice
-                        niimm = niimm + Ni_preice*1e-6_r8
-                        niimm = min(dst3_num, niimm)        ! niimm < dst_num 
-                     end if
-                  end if
                   nihf=0._r8
                   n1=niimm+nidep
 
@@ -282,18 +233,8 @@ subroutine nucleati(  &
                call hf(tc,wbar1,relhum,so4_num,nihf)
                niimm=0._r8
                nidep=0._r8
-
-               if (use_preexisting_ice) then
-                  if (nihf.gt.1e-3_r8) then !  hom occur,  add preexisting ice
-                     niimm=min(dst3_num,Ni_preice*1e-6_r8)       ! assuming dst_num freeze firstly
-                     nihf=nihf + Ni_preice*1e-6_r8 - niimm
-                  endif
-                  nihf=nihf*fhom
-                  n1=nihf+niimm 
-               else
-                  n1=nihf
-               end if
-
+               n1=nihf
+              
             ! transition between homogeneous and heterogeneous: interpolate in-between
             else
 
@@ -302,44 +243,18 @@ subroutine nucleati(  &
                   call hf(tc, wbar1, relhum, so4_num, nihf)
                   niimm = 0._r8
                   nidep = 0._r8
-
-                  if (use_preexisting_ice) then
-                     if (nihf .gt. 1e-3_r8) then ! hom occur,  add preexisting ice
-                        niimm = min(dst3_num, Ni_preice*1e-6_r8)       ! assuming dst_num freeze firstly
-                        nihf  = nihf + Ni_preice*1e-6_r8 - niimm
-                     endif
-                     nihf = nihf*fhom
-                     n1   = nihf + niimm
-                  else
-                     n1 = nihf
-                  end if
-
+                  n1 = nihf
+                  
                else
 
                   call hf(regm-5._r8,wbar1,relhum,so4_num,nihf)
                   call hetero(regm,wbar2,soot_num+dst3_num,niimm,nidep)
-
-                  if (use_preexisting_ice) then
-                     nihf = nihf*fhom
-                  end if
 
                   if (nihf .le. (niimm+nidep)) then
                      n1 = nihf
                   else
                      n1=(niimm+nidep)*((niimm+nidep)/nihf)**((tc-regm)/5._r8)
                   endif
-
-                  if (use_preexisting_ice) then
-                     if (n1 .gt. 1e-3_r8) then   ! add preexisting ice
-                        n1    = n1 + Ni_preice*1e-6_r8
-                        niimm = min(dst3_num, n1)  ! assuming all dst_num freezing earlier than hom  !!
-                        nihf  = n1 - niimm
-                     else
-                        n1    = 0._r8
-                        niimm = 0._r8
-                        nihf  = 0._r8                         
-                     endif
-                  end if
 
                end if
             end if
@@ -351,39 +266,6 @@ subroutine nucleati(  &
 #ifdef USE_XLIU_MOD
    end if
 #endif
-
-   if (use_dem_nucleate) then      ! DeMott, use particles number with D>0.5 um
-      !++iceMP
-
-      if(clim_modal_aero) then
-         if(cam_chempkg_is('trop_mam7') .or. cam_chempkg_is('trop_mam9')) then
-           na500_1  = dst1_num*0.566_r8
-         elseif(cam_chempkg_is('trop_mam3') .or. cam_chempkg_is('trop_mam4') .or. &
-              cam_chempkg_is('trop_mam4_resus') .or. cam_chempkg_is('trop_mam4_resus_soag')  .or. &
-              cam_chempkg_is('trop_mam4_mom') .or. cam_chempkg_is('trop_mam4_resus_mom') .or. &
-              cam_chempkg_is('linoz_mam3') .or. cam_chempkg_is('linoz_mam4_resus') .or. &
-              cam_chempkg_is('linoz_mam4_resus_soag') .or. cam_chempkg_is('linoz_mam4_resus_mom') .or. &
-              cam_chempkg_is('linoz_mam4_resus_mom_soag') .or. &
-              cam_chempkg_is('superfast_mam4_resus_mom_soag')) then !ASK Hailong about trop_mam4 
-            na500_1 = dst1_num*0.488_r8 + dst3_num
-         else
-            na500_1 = dst1_num*0.488_r8 + dst2_num + dst3_num + dst4_num   ! scaled for D>0.5-1 um from 0.1-1 um
-         endif
-      endif
-
-      ! prepare aerosol number and surface data for ice nucleation in mixed-phase clouds        
-      na500    = ( soot_num + organic_num ) * 0.0256_r8 + na500_1  ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
-
-      na500stp = na500 * 101325._r8 * tair/( 273.15_r8 * pmid ) ! at STP      
-      ad  = 1.25
-      bd  = -0.46*tc-11.6
-
-   !--iceMP   
-   endif
-
-   if (use_nie_nucleate) then  ! Niemand et al., surface area based
-      an = -0.517*tc + 8.934
-   endif
 
    ! deposition/condensation nucleation in mixed clouds (-37<T<0C) (Meyers, 1992)
    if(tc.lt.0._r8 .and. tc.gt.-37._r8 .and. qc.gt.1.e-12_r8) then
@@ -580,99 +462,6 @@ subroutine calculate_Ni_hf(A1, B1, C1, A2, B2, C2, Temperature, lnw, Na, Ni)
    Ni = min(Ni,Na)
 
 end subroutine
-
-SUBROUTINE Vpreice(P_in, T_in, R_in, C_in, S_in, V_out)
-
-   !  based on  Karcher et al. (2006)
-   !  VERTICAL VELOCITY CALCULATED FROM DEPOSITIONAL LOSS TERM
-
-   ! SUBROUTINE arguments
-   REAL(r8), INTENT(in)  :: P_in       ! [Pa],INITIAL AIR pressure 
-   REAL(r8), INTENT(in)  :: T_in       ! [K] ,INITIAL AIR temperature 
-   REAL(r8), INTENT(in)  :: R_in       ! [m],INITIAL MEAN  ICE CRYSTAL NUMBER RADIUS 
-   REAL(r8), INTENT(in)  :: C_in       ! [m-3],INITIAL TOTAL ICE CRYSTAL NUMBER DENSITY, [1/cm3]
-   REAL(r8), INTENT(in)  :: S_in       ! [-],INITIAL ICE SATURATION RATIO;; if <1, use hom threshold Si 
-   REAL(r8), INTENT(out) :: V_out      ! [m/s], VERTICAL VELOCITY REDUCTION (caused by preexisting ice)
-
-   ! SUBROUTINE parameters
-   REAL(r8), PARAMETER :: ALPHAc  = 0.5_r8 ! density of ice (g/cm3), !!!V is not related to ALPHAc 
-   REAL(r8), PARAMETER :: FA1c    = 0.601272523_r8        
-   REAL(r8), PARAMETER :: FA2c    = 0.000342181855_r8
-   REAL(r8), PARAMETER :: FA3c    = 1.49236645E-12_r8        
-   REAL(r8), PARAMETER :: WVP1c   = 3.6E+10_r8   
-   REAL(r8), PARAMETER :: WVP2c   = 6145.0_r8
-   REAL(r8), PARAMETER :: FVTHc   = 11713803.0_r8
-   REAL(r8), PARAMETER :: THOUBKc = 7.24637701E+18_r8
-   REAL(r8), PARAMETER :: SVOLc   = 3.23E-23_r8    ! SVOL=XMW/RHOICE
-   REAL(r8), PARAMETER :: FDc     = 249.239822_r8
-   REAL(r8), PARAMETER :: FPIVOLc = 3.89051704E+23_r8         
-   REAL(r8) :: T,P,S,R,C
-   REAL(r8) :: A1,A2,A3,B1,B2
-   REAL(r8) :: T_1,PICE,FLUX,ALP4,CISAT,DLOSS,VICE
-
-   T = T_in          ! K  , K
-   P = P_in*1e-2_r8  ! Pa , hpa
-
-   IF (S_in.LT.1.0_r8) THEN
-      S = 2.349_r8 - (T/259.0_r8) ! homogeneous freezing threshold, according to Ren & McKenzie, 2005
-   ELSE
-      S = S_in                    ! INPUT ICE SATURATION RATIO, -,  >1
-   ENDIF
-
-   R     = R_in*1e2_r8   ! m  => cm
-   C     = C_in*1e-6_r8  ! m-3 => cm-3
-   T_1   = 1.0_r8/ T
-   PICE  = WVP1c * EXP(-(WVP2c*T_1))
-   ALP4  = 0.25_r8 * ALPHAc      
-   FLUX  = ALP4 * SQRT(FVTHc*T)
-   CISAT = THOUBKc * PICE * T_1   
-   A1    = ( FA1c * T_1 - FA2c ) * T_1 
-   A2    = 1.0_r8/ CISAT      
-   A3    = FA3c * T_1 / P
-   B1    = FLUX * SVOLc * CISAT * ( S-1.0_r8 ) 
-   B2    = FLUX * FDc * P * T_1**1.94_r8 
-   DLOSS = FPIVOLc * C * B1 * R**2 / ( 1.0_r8+ B2 * R )         
-   VICE  = ( A2 + A3 * S ) * DLOSS / ( A1 * S )  ! 2006,(19)
-   V_out = VICE*1e-2_r8  ! cm/s => m/s
-
-END SUBROUTINE Vpreice
-
-subroutine frachom(Tmean,RHimean,detaT,fhom)
-   ! How much fraction of cirrus might reach Shom  
-   ! base on "A cirrus cloud scheme for general circulation models",
-   ! B. Karcher and U. Burkhardt 2008
-
-   real(r8), intent(in)  :: Tmean, RHimean, detaT
-   real(r8), intent(out) :: fhom
-
-   real(r8), parameter :: seta = 6132.9_r8  ! K
-   integer,  parameter :: Nbin=200          ! (Tmean - 3*detaT, Tmean + 3*detaT)
-
-   real(r8) :: PDF_T(Nbin)    ! temperature PDF;  ! PDF_T=0  outside (Tmean-3*detaT, Tmean+3*detaT)
-   real(r8) :: Sbin(Nbin)     ! the fluctuations of Si that are driven by the T variations 
-   real(r8) :: Sihom, deta
-   integer  :: i
-
-   Sihom = 2.349_r8-Tmean/259.0_r8   ! homogeneous freezing threshold, according to Ren & McKenzie, 2005
-   fhom  = 0.0_r8
-
-   do i = Nbin, 1, -1
-
-      deta     = (i - 0.5_r8 - Nbin/2)*6.0_r8/Nbin   ! PDF_T=0  outside (Tmean-3*detaT, Tmean+3*detaT)
-      Sbin(i)  = RHimean*exp(deta*detaT*seta/Tmean**2.0_r8)
-      PDF_T(i) = exp(-deta**2.0_r8/2.0_r8)*6.0_r8/(sqrt(2.0_r8*Pi)*Nbin)
-      
-
-      if (Sbin(i).ge.Sihom) then
-         fhom = fhom + PDF_T(i)
-      else
-         exit
-      end if
-   end do
-
-   fhom=fhom/0.997_r8   ! accounting for the finite limits (-3 , 3)
-
-end subroutine frachom
 
 end module nucleate_ice
 

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -800,19 +800,6 @@ subroutine nucleate_ice_cam_calc( &
    call outfld('NIDEP', nidep, pcols, lchnk)
    call outfld('NIMEY', nimey, pcols, lchnk)
 
-   if (use_preexisting_ice) then
-      call outfld( 'fhom' , fhom, pcols, lchnk)
-      call outfld( 'WICE' , wice, pcols, lchnk)
-      call outfld( 'WEFF' , weff, pcols, lchnk)
-      call outfld('INnso4  ',INnso4 , pcols,lchnk)
-      call outfld('INnbc   ',INnbc  , pcols,lchnk)
-      call outfld('INndust ',INndust, pcols,lchnk)
-      call outfld('INhet   ',INhet  , pcols,lchnk)
-      call outfld('INhom   ',INhom  , pcols,lchnk)
-      call outfld('INFrehom',INFrehom,pcols,lchnk)
-      call outfld('INFreIN ',INFreIN, pcols,lchnk)
-   end if
-
 end subroutine nucleate_ice_cam_calc
 
 !================================================================================================

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -809,10 +809,8 @@ subroutine nucleate_ice_cam_calc( &
                wsubi(i,k), t(i,k), pmid(i,k), relhum(i,k), icldm(i,k),   &
                qc(i,k), qi(i,k), ni(i,k), rho(i,k),                      &
                so4_num, dst_num, soot_num,                               &
-               dst1_sfc_to_num, dst3_sfc_to_num,                         &
                naai(i,k), nihf(i,k), niimm(i,k), nidep(i,k), nimey(i,k), &
-               wice(i,k), weff(i,k), fhom(i,k),                          &
-               dst1_num,dst2_num,dst3_num,dst4_num,organic_num,          &
+               dst1_num,dst2_num,dst3_num,dst4_num,                      &
                clim_modal_aero)
 
 


### PR DESCRIPTION
Remove unused codes for the following flags

**use_preexisting_ice** always false 
**use_dem_nucleate** always false
**use_nie_nucleate** always false
**use_hetfrz_classnuc** always true
**clim_modal_aero** always true

condition complie flags
**USE_XLIU_MOD** never turned on
**MODAL_AERO_4MODE_MOM** always turned on
**RAIN_EVAP_TO_COARSE_AERO** always turned on

subroutines Vpreice and frachom are removed in nucleate_ice.F90, because they are only used within use_preexisting_ice

Leave subroutine nucleate_ice_cam_init and nucleati_init mostly as it is. C++ will probably use different an approach.
