### PR TITLE
Adds Intel's one-api to address intel's license issue

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2446,7 +2446,7 @@
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
     </environment_variables>
     <environment_variables compiler="intel">
-      <env name="LD_LIBRARY_PATH">/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="LD_LIBRARY_PATH"> /share/apps/intel/oneapi:/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$ENV{LD_LIBRARY_PATH}</env>
     </environment_variables>
     <environment_variables mpilib="mvapich2">
       <env name="MV2_ENABLE_AFFINITY">0</env>


### PR DESCRIPTION
We frequently run into intel license issues where not enough intel licenses are available to compile the code. New intel one API fixes this issue as new intel compilers are free to use.

I tested it and the results are BFB with the baselines. This is due to the fact that we are using the same compiler underneath but just pointing the paths to Intel one API.