### PR TITLE
 Refactor nucleati in nucleate_ice.F90

### DIFF
--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -108,23 +108,23 @@ subroutine nucleati(  &
    !----------------------------------------------------------------
 
    ! Input Arguments
-   real(r8), intent(in) :: wbar        ! grid cell mean vertical velocity (m/s)
-   real(r8), intent(in) :: tair        ! temperature (K)
-   real(r8), intent(in) :: pmid        ! pressure at layer midpoints (pa)
-   real(r8), intent(in) :: relhum      ! relative humidity with respective to liquid
-   real(r8), intent(in) :: cldn        ! new value of cloud fraction    (fraction)
-   real(r8), intent(in) :: rhoair      ! air density (kg/m3)
-   real(r8), intent(in) :: so4_num     ! so4 aerosol number (#/cm^3)
-   real(r8), intent(in) :: dst_num     ! total dust aerosol number (#/cm^3)
-   real(r8), intent(in) :: soot_num    ! soot (hydrophilic) aerosol number (#/cm^3)
-   real(r8), intent(in) :: dst3_num     ! dust aerosol number (#/cm^3)
+   real(r8), intent(in) :: wbar        ! grid cell mean vertical velocity [m/s]
+   real(r8), intent(in) :: tair        ! temperature [K]
+   real(r8), intent(in) :: pmid        ! pressure at layer midpoints [pa]
+   real(r8), intent(in) :: relhum      ! relative humidity with respective to liquid [unitless]
+   real(r8), intent(in) :: cldn        ! new value of cloud fraction    [fraction]
+   real(r8), intent(in) :: rhoair      ! air density [kg/m3]
+   real(r8), intent(in) :: so4_num     ! so4 aerosol number [#/cm^3]
+   real(r8), intent(in) :: dst_num     ! total dust aerosol number [#/cm^3]
+   real(r8), intent(in) :: soot_num    ! soot (hydrophilic) aerosol number [#/cm^3]
+   real(r8), intent(in) :: dst3_num     ! dust aerosol number [#/cm^3]
 
    ! Output Arguments
-   real(r8), intent(out) :: nuci       ! ice number nucleated (#/kg)
-   real(r8), intent(out) :: onihf      ! nucleated number from homogeneous freezing of so4
-   real(r8), intent(out) :: oniimm     ! nucleated number from immersion freezing
-   real(r8), intent(out) :: onidep     ! nucleated number from deposition nucleation
-   real(r8), intent(out) :: onimey     ! nucleated number from deposition nucleation  (meyers: mixed phase)
+   real(r8), intent(out) :: nuci       ! ice number nucleated [#/kg]
+   real(r8), intent(out) :: onihf      ! nucleated number from homogeneous freezing of so4 [#/kg]
+   real(r8), intent(out) :: oniimm     ! nucleated number from immersion freezing [#/kg]
+   real(r8), intent(out) :: onidep     ! nucleated number from deposition nucleation [#/kg]
+   real(r8), intent(out) :: onimey     ! nucleated number from deposition nucleation  (meyers: mixed phase) [#/kg]
 
    ! Local workspace
    real(r8) :: nihf                      ! nucleated number from homogeneous freezing of so4

--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -133,8 +133,8 @@ subroutine nucleati(  &
    real(r8) :: nimey                     ! nucleated number from deposition nucleation (meyers)
    real(r8) :: n1, ni                    ! nucleated number
    real(r8) :: tc, regm                  ! work variable  
-   real(r8) :: aer_num
-   real(r8) :: wbar1, wbar2 
+   real(r8) :: soot_dst3_num
+   real(r8) :: wbar1, wbar2
 
    !-------------------------------------------------------------------------------
 
@@ -144,7 +144,7 @@ subroutine nucleati(  &
 
    ni = 0._r8
    tc = tair - 273.15_r8
-   aer_num = soot_num + dst3_num
+   soot_dst3_num = soot_num + dst3_num
 
    ! initialize
    niimm = 0._r8
@@ -152,11 +152,11 @@ subroutine nucleati(  &
    nihf  = 0._r8
 
 
-   if(so4_num >= 1.0e-10_r8 .and. aer_num >= 1.0e-10_r8 .and. cldn > 0._r8) then
+   if(so4_num >= 1.0e-10_r8 .and. soot_dst3_num >= 1.0e-10_r8 .and. cldn > 0._r8) then
 
       if((tc <= -35.0_r8) .and. ((relhum*svp_water(tair)/svp_ice(tair)*subgrid) >= 1.2_r8)) then ! use higher RHi threshold
 
-            call calculate_regm_nucleati(wbar1, aer_num, regm)
+            call calculate_regm_nucleati(wbar1, soot_dst3_num, regm)
 
             ! heterogeneous nucleation only
             if (tc > regm) then
@@ -170,7 +170,7 @@ subroutine nucleati(  &
                   
                else
 
-                  call hetero(tc,wbar2,aer_num,niimm,nidep)
+                  call hetero(tc,wbar2,soot_dst3_num,niimm,nidep)
                   nihf=0._r8
                   n1=niimm+nidep
 
@@ -197,7 +197,7 @@ subroutine nucleati(  &
                else
 
                   call hf(regm-5._r8,wbar1,relhum,so4_num,nihf)
-                  call hetero(regm,wbar2,aer_num,niimm,nidep)
+                  call hetero(regm,wbar2,soot_dst3_num,niimm,nidep)
 
                   if (nihf <= (niimm+nidep)) then
                      n1 = nihf

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -356,9 +356,6 @@ subroutine nucleate_ice_cam_calc( &
 
    real(r8), pointer :: t(:,:)          ! input temperature (K)
    real(r8), pointer :: qn(:,:)         ! input water vapor mixing ratio (kg/kg)
-   real(r8), pointer :: qc(:,:)         ! cloud water mixing ratio (kg/kg)
-   real(r8), pointer :: qi(:,:)         ! cloud ice mixing ratio (kg/kg)
-   real(r8), pointer :: ni(:,:)         ! cloud ice number conc (1/kg)
    real(r8), pointer :: pmid(:,:)       ! pressure at layer midpoints (pa)
 
    real(r8), pointer :: num_accum(:,:)  ! number m.r. of accumulation mode
@@ -414,9 +411,6 @@ subroutine nucleate_ice_cam_calc( &
    ncol  = state%ncol
    t     => state%t
    qn    => state%q(:,:,1)
-   qc    => state%q(:,:,cldliq_idx)
-   qi    => state%q(:,:,cldice_idx)
-   ni    => state%q(:,:,numice_idx)
    pmid  => state%pmid
 
    do k = top_lev, pver

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -531,11 +531,9 @@ subroutine nucleate_ice_cam_calc( &
 
             call nucleati( &
                wsubi(i,k), t(i,k), pmid(i,k), relhum(i,k), icldm(i,k),   &
-               qc(i,k), qi(i,k), ni(i,k), rho(i,k),                      &
-               so4_num, dst_num, soot_num,                               &
+               rho(i,k), so4_num, dst_num, soot_num,                     &
                naai(i,k), nihf(i,k), niimm(i,k), nidep(i,k), nimey(i,k), &
-               dst1_num,dst2_num,dst3_num,dst4_num,                      &
-               clim_modal_aero)
+               dst3_num)
 
 
             naai_hom(i,k) = nihf(i,k)


### PR DESCRIPTION
Refactor subroutine nucleati in nucleate_ice.F90

Using one variable to replace 1.e+6_r8/rhoair causes NBFB. Currently leave it as it is.