### PR TITLE
refactor ma_convproc_intr

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2134,8 +2134,7 @@ do_lphase2_conditional: &
             dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
             nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
             mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
-            species_class,                                              &
-            history_aero_prevap_resusp                                  )
+            species_class                                               )
        call t_stopf('ma_convproc')       
     endif
 

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2128,7 +2128,7 @@ do_lphase2_conditional: &
        call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
 
        call t_startf('ma_convproc')
-       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
+       call ma_convproc_intr( state, ptend, dt,                         &
             dp_frac, icwmrdp, rprddp, evapcdp,                          &
             sh_frac, icwmrsh, rprdsh, evapcsh,                          &
             dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2128,13 +2128,13 @@ do_lphase2_conditional: &
        call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
 
        call t_startf('ma_convproc')
-       call ma_convproc_intr( state, ptend, dt,                         &
-            dp_frac, icwmrdp, rprddp, evapcdp,                          &
-            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
-            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
-            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
-            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
-            species_class                                               )
+       call ma_convproc_intr( state, dt,                      & ! in
+            dp_frac, icwmrdp, rprddp, evapcdp,                & ! in
+            sh_frac, icwmrsh, rprdsh, evapcsh,                & ! in
+            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                 & ! in
+            mu, md, du, eu, ed, dp, jt, maxg,                 & ! in
+            ideep, lengath,  species_class,                   & ! in
+            ptend, aerdepwetis                                ) ! inout
        call t_stopf('ma_convproc')       
     endif
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -44,7 +44,7 @@ module modal_aero_convproc
    logical, parameter :: use_cwaer_for_activate_maxsat = .false.
    logical, parameter :: apply_convproc_tend_to_ptend = .true.
 
-   real(r8) :: hund_ovr_g ! = 100.0_r8/gravit
+   real(r8) :: hund_ovr_g  != 100.0_r8/gravit
 !  used with zm_conv mass fluxes and delta-p
 !     for mu = [mbar/s],   mu*hund_ovr_g = [kg/m2/s]
 !     for dp = [mbar] and q = [kg/kg],   q*dp*hund_ovr_g = [kg/m2]
@@ -230,7 +230,8 @@ subroutine ma_convproc_intr( state, ztodt,                          & ! in
   dotend(:) = ptend%lq(:)
   dqdt(:,:,:) = ptend%q(:,:,:)
   hund_ovr_g = 100.0_r8/gravit
-!  used with zm_conv mass fluxes and delta-p
+!  used with zm_conv mass fluxes and delta-p. This is also used in other
+!  subroutines in this file since it is declared at the beginning.
 !     for mu = [mbar/s],   mu*hund_ovr_g = [kg/m2/s]
 !     for dp = [mbar] and q = [kg/kg],   q*dp*hund_ovr_g = [kg/m2]
 
@@ -297,7 +298,9 @@ subroutine update_qnew_ptend(                                         &
                            ncol,   species_class,   dqdt,             &  ! in
                            qsrflx, ztodt,                             &  ! in
                            ptend,  qnew,            aerdepwetis       )  ! inout
-
+! ---------------------------------------------------------------------------------------
+! update qnew, ptend (%q and %lq) and wet deposition variable aerdepwetis
+! ---------------------------------------------------------------------------------------  
 use physics_types, only: physics_ptend
 use constituents,  only: pcnst
 


### PR DESCRIPTION
`history_aero_prevap_resusp `and `history_aero_prevap_resusp` are always true in this subroutine. remove it.

separate the calculation of deep and shallow convective processing tendency as a subroutine `update_qnew_ptend `and also apply it to processing preparation.
