### PR TITLE
Refactor coagulation

### DIFF
--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -2074,16 +2074,12 @@ do_newnuc_if_block50: &
       qaer_sv1 = qaer_cur
 
       call mam_coag_1subarea(                                       &
-         nstep,             lchnk,                                  &
-         i,                 k,                jsub,                 &
-         latndx,            lonndx,           lund,                 &
          dtsubstep,                                                 &
          temp,              pmid,             aircon,               &
          dgn_a,             dgn_awet,         wetdens,              &
          n_mode,                                                    &
          qnum_cur,                                                  &
-         qaer_cur,          qaer_delsub_coag_in,                    &
-         qwtr_cur                                                   )
+         qaer_cur,          qaer_delsub_coag_in                     )
 
       qnum_delsub_coag = qnum_cur - qnum_sv1
       qaer_delsub_coag = qaer_cur - qaer_sv1
@@ -5044,6 +5040,12 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
             write(iulog,'(4i5,2x,a)') &
                lmz+loffset, lmz, lmapcc_all(lmz), j, solsym(lmz)
          end do
+
+         write(iulog,'(/a)') 'coag: ipair, modefrm, modetoo, modeend'
+         do ipair = 1,n_coagpair
+            write(iulog,*) ipair, modefrm_coagpair(ipair), modetoo_coagpair(ipair), modeend_coagpair(ipair)
+         end do
+         write(iulog,'(a/)') 'coag: ----'
 
       end if ! ( masterproc )
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -4895,7 +4895,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       n_agepair = ipair
 
 ! coagulation pairs
-      call set_coagulation_pairs( masterproc, big_neg_int )
+      call set_coagulation_pairs( masterproc )
 
 ! diagnostics
       if ( masterproc ) then

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -1361,7 +1361,7 @@ main_jsub_loop: &
       integer :: iaer, igas, ip
       integer :: jtsubstep
       integer :: ll
-      integer :: modefrm, modetoo
+      integer :: src_mode, dest_mode
 ! if mtoo_renamexf(n) >  0, then mode n gets renamed into mode mtoo_renamexf(n)
 ! if mtoo_renamexf(n) <= 0, then mode n does not have renaming
       integer :: mtoo_renamexf(max_mode)
@@ -1802,7 +1802,7 @@ do_rename_if_block30: &
       integer :: iaer, igas, ip
       integer :: jtsubstep
       integer :: ll
-      integer :: modefrm, modetoo
+      integer :: src_mode, dest_mode
 ! if mtoo_renamexf(n) >  0, then mode n gets renamed into mode mtoo_renamexf(n)
 ! if mtoo_renamexf(n) <= 0, then mode n does not have renaming
       integer :: mtoo_renamexf(max_mode)
@@ -5067,7 +5067,7 @@ use modal_aero_data, only : &
     modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine
 !use modal_aero_rename
 
-use modal_aero_coag, only: n_coagpair, modefrm_coagpair, modetoo_coagpair, modeend_coagpair
+use modal_aero_coag, only: n_coagpair, src_mode_coagpair, dest_mode_coagpair, end_mode_coagpair
 
 implicit none
 
@@ -5231,9 +5231,9 @@ implicit none
 
 ! coagulation
       do ipair = 1, n_coagpair
-         na = modefrm_coagpair(ipair)
-         nb = modetoo_coagpair(ipair)
-         nc = modeend_coagpair(ipair)
+         na =  src_mode_coagpair(ipair)
+         nb = dest_mode_coagpair(ipair)
+         nc =  end_mode_coagpair(ipair)
          if (na < 1 .or. nb < 1 .or. nc < 1) cycle
 
          lmza = lmap_num(na)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -4895,12 +4895,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       n_agepair = ipair
 
 ! coagulation pairs
-#if ( defined MODAL_AERO_4MODE_MOM )
       call set_coagulation_pairs( big_neg_int )
-#else
-      call endrun("only MODAL_AERO_4MODE_MOM is supported")
-#endif
-
 
 ! diagnostics
       if ( masterproc ) then

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -2074,12 +2074,10 @@ do_newnuc_if_block50: &
       qaer_sv1 = qaer_cur
 
       call mam_coag_1subarea(                                       &
-         dtsubstep,                                                 &
-         temp,              pmid,             aircon,               &
-         dgn_a,             dgn_awet,         wetdens,              &
-         n_mode,                                                    &
-         qnum_cur,                                                  &
-         qaer_cur,          qaer_delsub_coag_in                     )
+         dtsubstep,                                                 &! in
+         temp,              pmid,             aircon,               &! in
+         dgn_a,             dgn_awet,         wetdens,              &! in
+         qnum_cur,          qaer_cur,         qaer_delsub_coag_in   )! inout, inout, out
 
       qnum_delsub_coag = qnum_cur - qnum_sv1
       qaer_delsub_coag = qaer_cur - qaer_sv1
@@ -4477,6 +4475,8 @@ use modal_aero_data, only : &
     nspec_amode, &
     numptr_amode, numptrcw_amode, sigmag_amode
 
+use modal_aero_coag, only: set_coagulation_pairs
+
 implicit none
 
 !-----------------------------------------------------------------------
@@ -4895,71 +4895,11 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       n_agepair = ipair
 
 ! coagulation pairs
-!
-! mam version	modes involved in coagulation          # of coag pairs
-! -----------   -----------------------------          ---------------
-! 3 mode	accum, aitken                              1
-! 4,7 mode	accum, aitken, pcarbon                     3
-! 9 mode	accum, aitken, pcarbon, maccum, maitken   10
-! (pcarbon = primary carbon)
-! (maccum  = primary marine-organics accum)
-! (maitken = primary marine-organics aitken)
-!
-! 9 mode -- 5 participating modes and 10 possible coagulation pairs
-!    6 possible coagulation pairs involve a smaller and a larger sized mode
-!       the resulting particle is placed in the larger-sized mode
-!          aitken  + [ accum, pcarbon, maccum ]
-!          maitken + [ accum, pcarbon, maccum ]
-!    4 possible coagulation pairs involve similar sized modes
-!       the resulting particle is placed in the mode that is aged 
-!       or contains the largest number of species
-!          pcarbon + accum   --> accum   (aged)
-!          maitken + aitken  --> aitken  (aged)
-!          maccum  + accum   --> accum   (aged)
-!          maccum  + pcarbon --> pcarbon (largest number of species)
-!    note that 2 of the coagulation pairs results in aging, so
-!          aitken  + pcarbon --> pcarbon (temporary) --> accum
-!          aitken  + maccum  --> maccum  (temporary) --> accum
-!    each mode also has self-coagulation which only affects number
-      ipair = 0
-      modefrm_coagpair(:) = big_neg_int
-      modetoo_coagpair(:) = big_neg_int
-      modeend_coagpair(:) = big_neg_int
-      do ip = 1, 11
-         na = big_neg_int ; nb = big_neg_int
-         nc = big_pos_int
-         if (ip == 1) then
-            na = nait ; nb = nacc
-         else if (ip == 2) then
-            na = npca ; nb = nacc
-         else if (ip == 3) then
-            na = nait ; nb = npca
-            nc = nacc
-         else if (ip == 4) then
-            na = nait ; nb = nmacc
-            nc = nacc
-         else if (ip == 5) then
-            na = nmait ; nb = nacc
-         else if (ip == 6) then
-            na = nmait ; nb = npca
-         else if (ip == 7) then
-            na = nmait ; nb = nait
-         else if (ip == 8) then
-            na = nmait ; nb = nmacc
-         else if (ip == 9) then
-            na = nmacc ; nb = nacc
-         else if (ip == 10) then
-            na = nmacc ; nb = npca
-         end if
-         if (nc == big_pos_int) nc = nb
-
-         if (na < 1 .or. nb < 1 .or. nc < 1) cycle
-         ipair = ipair + 1
-         modefrm_coagpair(ipair) = na
-         modetoo_coagpair(ipair) = nb
-         modeend_coagpair(ipair) = nc
-      end do
-      n_coagpair = ipair
+#if ( defined MODAL_AERO_4MODE_MOM )
+      call set_coagulation_pairs( big_neg_int )
+#else
+      call endrun("only MODAL_AERO_4MODE_MOM is supported")
+#endif
 
 
 ! diagnostics

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -4895,7 +4895,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       n_agepair = ipair
 
 ! coagulation pairs
-      call set_coagulation_pairs( big_neg_int )
+      call set_coagulation_pairs( masterproc, big_neg_int )
 
 ! diagnostics
       if ( masterproc ) then
@@ -4975,12 +4975,6 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
             write(iulog,'(4i5,2x,a)') &
                lmz+loffset, lmz, lmapcc_all(lmz), j, solsym(lmz)
          end do
-
-         write(iulog,'(/a)') 'coag: ipair, modefrm, modetoo, modeend'
-         do ipair = 1,n_coagpair
-            write(iulog,*) ipair, modefrm_coagpair(ipair), modetoo_coagpair(ipair), modeend_coagpair(ipair)
-         end do
-         write(iulog,'(a/)') 'coag: ----'
 
       end if ! ( masterproc )
 
@@ -5072,6 +5066,8 @@ use modal_aero_data, only : &
     cnst_name_cw, &
     modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine
 !use modal_aero_rename
+
+use modal_aero_coag, only: n_coagpair, modefrm_coagpair, modetoo_coagpair, modeend_coagpair
 
 implicit none
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
@@ -129,12 +129,16 @@
   integer, parameter :: max_mode = ntot_amode_extd + max_mode_fresh
   public max_mode !BSINGH - used in module_mosaic_cam_init.F90
 
-  integer, parameter :: max_coagpair = 100
 
 #if ( defined MODAL_AERO_9MODE )
   integer, parameter :: max_agepair = 3
+  integer, parameter :: max_coagpair = 100
+#elif ( defined MODAL_AERO_4MODE_MOM )
+  integer, parameter :: max_agepair = 1
+  integer, parameter :: max_coagpair = 3 
 #else
   integer, parameter :: max_agepair = 1
+  integer, parameter :: max_coagpair = 100 
 #endif
 
   integer, parameter :: maxsubarea = 2

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
@@ -130,16 +130,8 @@
   public max_mode !BSINGH - used in module_mosaic_cam_init.F90
 
 
-#if ( defined MODAL_AERO_9MODE )
-  integer, parameter :: max_agepair = 3
-  integer, parameter :: max_coagpair = 100
-#elif ( defined MODAL_AERO_4MODE_MOM )
   integer, parameter :: max_agepair = 1
   integer, parameter :: max_coagpair = 3 
-#else
-  integer, parameter :: max_agepair = 1
-  integer, parameter :: max_coagpair = 100 
-#endif
 
   integer, parameter :: maxsubarea = 2
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys_control.F90
@@ -131,7 +131,6 @@
 
 
   integer, parameter :: max_agepair = 1
-  integer, parameter :: max_coagpair = 3 
 
   integer, parameter :: maxsubarea = 2
 
@@ -168,11 +167,9 @@
   integer :: ngas, naer
   integer :: nacc, nait, npca, nufi, nmacc, nmait
 
-  integer :: n_agepair, n_coagpair
+  integer :: n_agepair
   integer :: modefrm_agepair(max_agepair), modetoo_agepair(max_agepair)
   integer :: mode_aging_optaa(max_mode)
-  integer :: modefrm_coagpair(max_coagpair), modetoo_coagpair(max_coagpair), &
-             modeend_coagpair(max_coagpair)
 
   integer :: lun82,   lun97,   lun98,   lun13n,   lun15n
   logical :: ldiag82, ldiag97, ldiag98, ldiag13n, ldiag15n

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -600,7 +600,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     real(wp) sqdgat, sqdgac
     real(wp) sqdgat5, sqdgac5
     real(wp) sqdgat7
-    real(wp) r, r2, r3, rx4
+    real(wp) r1, r2, r3, rx4
     real(wp) ri1, ri2, ri3
     real(wp) rat
     real(wp) coagfm0, coagnc0
@@ -1290,11 +1290,11 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     !------------------------------------------------------------------
     ! For the free molecular regime:  page h.3 of whitby et al. (1991)
     !------------------------------------------------------------------
-    r       = sqdgac / sqdgat
-    r2      = r * r
-    r3      = r2 * r
+    r1      = sqdgac / sqdgat
+    r2      = r1 * r1
+    r3      = r2 * r1
     rx4     = r2 * r2
-    ri1     = one / r
+    ri1     = one / r1
     ri2     = one / r2
     ri3     = one / r3
     kngat   = two * lamda / dgatk
@@ -1324,7 +1324,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     ! Free-molecular form:  equation h.7a of whitby et al. (1991)
 
     coagfm0 = kfmatac * sqdgat * bm0ij(n1,n2n,n2a) * (   &
-      esat01 + r * esac01 + two * r2 * esat01 * esac04   &
+      esat01 + r1 * esac01 + two * r2 * esat01 * esac04   &
       + rx4 * esat09 * esac16 + ri3 * esat16 * esac09   &
       + two * ri1 * esat04 + esac01  )
 
@@ -1347,7 +1347,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     coagfm3 = kfmatac * sqdgat7 * bm3i( n1, n2n, n2a ) * (   &
       esat49   &
-      +  r * esat36  * esac01   &
+      +  r1 * esat36  * esac01   &
       + two * r2 * esat25  * esac04   &
       + rx4 * esat09  * esac16   &
       + ri3 * esat100 * esac09   &

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -46,14 +46,14 @@ subroutine set_coagulation_pairs( masterproc )
 
    integer :: ip                      ! coagulation pair index
 
-   integer, parameter :: big_neg_int = -huge(selected_int_kind(6))
+   integer, parameter :: huge_neg_int = -huge(huge_neg_int)
 
    !---------------------------------------------------------------------------------------------------
    ! Assign values to the bookkeeping arrays that specify the iner-modal mass/number transfer pathways.
    !---------------------------------------------------------------------------------------------------
-   modefrm_coagpair(:) = big_neg_int
-   modetoo_coagpair(:) = big_neg_int
-   modeend_coagpair(:) = big_neg_int
+   modefrm_coagpair(:) = huge_neg_int
+   modetoo_coagpair(:) = huge_neg_int
+   modeend_coagpair(:) = huge_neg_int
 
    ip=1; modefrm_coagpair(ip)=nait; modetoo_coagpair(ip)=nacc; modeend_coagpair(ip)=nacc
    ip=2; modefrm_coagpair(ip)=npca; modetoo_coagpair(ip)=nacc; modeend_coagpair(ip)=nacc

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -32,7 +32,7 @@ module modal_aero_coag
 
 contains
 
-subroutine set_coagulation_pairs( masterproc, big_neg_int )
+subroutine set_coagulation_pairs( masterproc )
 !----------------------------------------------------------------------
 ! Purpose: Set up coagulation pairs during model initialization.
 !
@@ -43,8 +43,10 @@ subroutine set_coagulation_pairs( masterproc, big_neg_int )
 !----------------------------------------------------------------------
 
    logical, intent(in) :: masterproc  ! if we are on the master process of an MPI run
-   integer, intent(in) :: big_neg_int
+
    integer :: ip                      ! coagulation pair index
+
+   integer, parameter :: big_neg_int = -huge(selected_int_kind(6))
 
    !---------------------------------------------------------------------------------------------------
    ! Assign values to the bookkeeping arrays that specify the iner-modal mass/number transfer pathways.

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -604,14 +604,12 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     real(wp) ri1, ri2, ri3
     real(wp) rat
     real(wp) coagfm0, coagnc0
-    real(wp) coagfm3, coagnc3
     real(wp) coagfm_at, coagfm_ac
     real(wp) coagnc_at, coagnc_ac
 
     ! Correction factors for coagulation rates
     real(wp), save :: bm0( 10 )           ! m0 intramodal fm - rpm values
     real(wp), save :: bm0ij( 10, 10, 10 ) ! m0 intermodal fm
-    real(wp), save :: bm3i( 10, 10, 10 )  ! m3 intermodal fm- rpm values
 
     ! Populate the arrays for the correction factors *************************************
 
@@ -926,7 +924,177 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
       0.999244_wp,  0.999464_wp,  0.999622_wp,  0.999733_wp,  0.999811_wp/
 
 
+    ! *** end of data statements *************************************
+
+    !----------------------------------------------------------
+    ! Start calculations
+    !----------------------------------------------------------
+    ! Constants and parameters
+
+    sqrttwo = sqrt(two)
+    dlgsqt2 = one / log( sqrttwo )
+
+    esat01   = exp( 0.125_wp * xxlsgat * xxlsgat )
+    esac01   = exp( 0.125_wp * xxlsgac * xxlsgac )
+
+    esat04  = esat01 ** 4
+    esac04  = esac01 ** 4
+
+    esat05  = esat04 * esat01
+    esac05  = esac04 * esac01
+
+    esat08  = esat04 * esat04
+    esac08  = esac04 * esac04
+
+    esat09  = esat08 * esat01
+    esac09  = esac08 * esac01
+
+    esat16  = esat08 * esat08
+    esac16  = esac08 * esac08
+
+    esat20  = esat16 * esat04
+    esac20  = esac16 * esac04
+
+    esat24  = esat20 * esat04
+    esac24  = esac20 * esac04
+
+    esat25  = esat20 * esat05
+    esac25  = esac20 * esac05
+
+    esat36  = esat20 * esat16
+    esac36  = esac20 * esac16
+
+    esat49  = esat24 * esat25
+
+    esat64  = esat20 * esat20 * esat24
+    esac64  = esac20 * esac20 * esac24
+
+    esat100 = esat64 * esat36
+
+    dgat2   = dgatk * dgatk
+    dgat3   = dgatk * dgatk * dgatk
+    dgac2   = dgacc * dgacc
+    dgac3   = dgacc * dgacc * dgacc
+
+    sqdgat  = sqrt( dgatk )
+    sqdgac  = sqrt( dgacc )
+    sqdgat5 = dgat2 * sqdgat
+    sqdgac5 = dgac2 * sqdgac
+    sqdgat7 = dgat3 * sqdgat
+
+    !------------------------------------------------------------------
+    ! For the free molecular regime:  page h.3 of whitby et al. (1991)
+    !------------------------------------------------------------------
+    r1      = sqdgac / sqdgat
+    r2      = r1 * r1
+    r3      = r2 * r1
+    rx4     = r2 * r2
+    ri1     = one / r1
+    ri2     = one / r2
+    ri3     = one / r3
+    kngat   = two * lamda / dgatk
+    kngac   = two * lamda / dgacc
+
+    ! Calculate ratio of geometric mean diameters
+
+    rat = dgacc / dgatk
+
+    ! Trap subscripts for bm0 and bm0i, between 1 and 10.
+    ! See page h.5 of whitby et al. (1991)
+
+    n2n = max( 1, min( 10,   nint( 4.0_wp * ( sgatk - 0.75_wp ) ) ) )
+    n2a = max( 1, min( 10,   nint( 4.0_wp * ( sgacc - 0.75_wp ) ) ) )
+    n1  = max( 1, min( 10,   1 + nint( dlgsqt2 * log( rat ) ) ) )
+
+    !----------------------------------------------------
+    ! Intermodal coagulation, set up for zeroth moment
+    !----------------------------------------------------
+    ! Near-continuum form:  equation h.10a of whitby et al. (1991)
+
+    coagnc0 = knc * (   &
+      two + a_const * ( kngat * ( esat04 + r2 * esat16 * esac04 )   &
+      + kngac * ( esac04 + ri2 * esac16 * esat04 ) )   &
+      + ( r2 + ri2 ) * esat04 * esac04  )
+
+    ! Free-molecular form:  equation h.7a of whitby et al. (1991)
+
+    coagfm0 = kfmatac * sqdgat * bm0ij(n1,n2n,n2a) * (   &
+      esat01 + r1 * esac01 + two * r2 * esat01 * esac04   &
+      + rx4 * esat09 * esac16 + ri3 * esat16 * esac09   &
+      + two * ri1 * esat04 + esac01  )
+
+    ! Loss to accumulation mode, harmonic mean
+
+    qn12 = coagnc0 * coagfm0 / ( coagnc0 + coagfm0 )
+
+    !-----------------------------------------------------------------
+    ! Aitken to accumulation mode coagulation rate for the 3rd moment
+    !-----------------------------------------------------------------
+    call intermodal_coag_rate_for_3rd_moment(             &! in
+         two, a_const, r1, r2, rx4, ri1, ri2, ri3,        &! in 
+         knc, kngat, kngac, dgat3, kfmatac, sqdgat7,      &! in
+         esat04, esat16, esat36, esat64, esac04, esac16,  &! in 
+         esat09, esat25, esat49, esat100, esac01, esac09, &! in
+         n1, n2a, n2n,                                    &! in
+         qv12 )                                            ! out
+
+    !-----------------------------------------------------
+    ! Intramodal coagulation
+    !-----------------------------------------------------
+    ! aitken mode
+    !--------------
+    ! Near-continuum form: equation h.12a of whitby et al. (1991)
+    coagnc_at = knc * (one + esat08 + a_const * kngat * (esat20 + esat04))
+
+    ! Free-molecular form: equation h.11a of whitby et al. (1991)
+    coagfm_at = kfmat * sqdgat * bm0(n2n) *  ( esat01 + esat25 + two * esat05 )
+
+    ! Harmonic mean
+    qn11 = coagfm_at * coagnc_at / ( coagfm_at + coagnc_at )
+
+    !-------------------
+    ! accumulation mode
+    !-------------------
+    ! Near-continuum form: equation h.12a of whitby et al. (1991)
+    coagnc_ac = knc * (one + esac08 + a_const * kngac * (esac20 + esac04))
+
+    ! Free-molecular form: equation h.11a of whitby et al. (1991)
+    coagfm_ac = kfmac * sqdgac * bm0(n2a) * ( esac01 + esac25 + two * esac05 )
+
+    ! Harmonic mean
+    qn22 = coagfm_ac * coagnc_ac / ( coagfm_ac + coagnc_ac )
+
+end subroutine getcoags
+
+
+subroutine intermodal_coag_rate_for_3rd_moment( two, a_const, r1, r2, rx4, ri1, ri2, ri3,        &! in 
+                                                knc, kngat, kngac, dgat3, kfmatac, sqdgat7,      &! in
+                                                esat04, esat16, esat36, esat64, esac04, esac16,  &! in 
+                                                esat09, esat25, esat49, esat100, esac01, esac09, &! in
+                                                n1, n2a, n2n,                                    &! in
+                                                qv12 )                                            ! out
+
+    real(wp),intent(in)  :: two, a_const
+    real(wp),intent(in)  :: r1, r2, rx4, ri1, ri2, ri3
+
+    real(wp),intent(in)  :: knc, kngat, kngac, dgat3
+    real(wp),intent(in)  :: esat04, esat16, esat36, esat64
+    real(wp),intent(in)  :: esac04
+
+    real(wp),intent(in)  :: kfmatac, sqdgat7 
+    real(wp),intent(in)  :: esat09, esat25, esat49, esat100
+    real(wp),intent(in)  :: esac01, esac09, esac16
+
+    integer, intent(in)  :: n1, n2a, n2n ! indices for correction factors
+
+    real(wp),intent(out) :: qv12
+
+    real(wp) coagfm3, coagnc3
+
     ! rpm....   3rd moment nuclei mode corr. fac. for bimodal fm coag rate
+    real(wp), save :: bm3i( 10, 10, 10 )  ! m3 intermodal fm-rpm values
+
+    integer :: ibeta
 
     data (bm3i( 1, 1,ibeta ), ibeta=1,10)/   &
       0.70708_wp,0.71681_wp,0.73821_wp,0.76477_wp,0.79350_wp,0.82265_wp,0.85090_wp,0.87717_wp,   &
@@ -1229,112 +1397,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
       0.97977_wp,0.98071_wp,0.98270_wp,0.98492_wp,0.98695_wp,0.98858_wp,0.98970_wp,0.99027_wp,   &
       0.99026_wp,0.98968_wp/
 
-    ! *** end of data statements *************************************
 
-    !----------------------------------------------------------
-    ! Start calculations
-    !----------------------------------------------------------
-    ! Constants and parameters
-
-    sqrttwo = sqrt(two)
-    dlgsqt2 = one / log( sqrttwo )
-
-    esat01   = exp( 0.125_wp * xxlsgat * xxlsgat )
-    esac01   = exp( 0.125_wp * xxlsgac * xxlsgac )
-
-    esat04  = esat01 ** 4
-    esac04  = esac01 ** 4
-
-    esat05  = esat04 * esat01
-    esac05  = esac04 * esac01
-
-    esat08  = esat04 * esat04
-    esac08  = esac04 * esac04
-
-    esat09  = esat08 * esat01
-    esac09  = esac08 * esac01
-
-    esat16  = esat08 * esat08
-    esac16  = esac08 * esac08
-
-    esat20  = esat16 * esat04
-    esac20  = esac16 * esac04
-
-    esat24  = esat20 * esat04
-    esac24  = esac20 * esac04
-
-    esat25  = esat20 * esat05
-    esac25  = esac20 * esac05
-
-    esat36  = esat20 * esat16
-    esac36  = esac20 * esac16
-
-    esat49  = esat24 * esat25
-
-    esat64  = esat20 * esat20 * esat24
-    esac64  = esac20 * esac20 * esac24
-
-    esat100 = esat64 * esat36
-
-    dgat2   = dgatk * dgatk
-    dgat3   = dgatk * dgatk * dgatk
-    dgac2   = dgacc * dgacc
-    dgac3   = dgacc * dgacc * dgacc
-
-    sqdgat  = sqrt( dgatk )
-    sqdgac  = sqrt( dgacc )
-    sqdgat5 = dgat2 * sqdgat
-    sqdgac5 = dgac2 * sqdgac
-    sqdgat7 = dgat3 * sqdgat
-
-    !------------------------------------------------------------------
-    ! For the free molecular regime:  page h.3 of whitby et al. (1991)
-    !------------------------------------------------------------------
-    r1      = sqdgac / sqdgat
-    r2      = r1 * r1
-    r3      = r2 * r1
-    rx4     = r2 * r2
-    ri1     = one / r1
-    ri2     = one / r2
-    ri3     = one / r3
-    kngat   = two * lamda / dgatk
-    kngac   = two * lamda / dgacc
-
-    ! Calculate ratio of geometric mean diameters
-
-    rat = dgacc / dgatk
-
-    ! Trap subscripts for bm0 and bm0i, between 1 and 10.
-    ! See page h.5 of whitby et al. (1991)
-
-    n2n = max( 1, min( 10,   nint( 4.0_wp * ( sgatk - 0.75_wp ) ) ) )
-    n2a = max( 1, min( 10,   nint( 4.0_wp * ( sgacc - 0.75_wp ) ) ) )
-    n1  = max( 1, min( 10,   1 + nint( dlgsqt2 * log( rat ) ) ) )
-
-    !----------------------------------------------------
-    ! Intermodal coagulation, set up for zeroeth moment
-    !----------------------------------------------------
-    ! Near-continuum form:  equation h.10a of whitby et al. (1991)
-
-    coagnc0 = knc * (   &
-      two + a_const * ( kngat * ( esat04 + r2 * esat16 * esac04 )   &
-      + kngac * ( esac04 + ri2 * esac16 * esat04 ) )   &
-      + ( r2 + ri2 ) * esat04 * esac04  )
-
-    ! Free-molecular form:  equation h.7a of whitby et al. (1991)
-
-    coagfm0 = kfmatac * sqdgat * bm0ij(n1,n2n,n2a) * (   &
-      esat01 + r1 * esac01 + two * r2 * esat01 * esac04   &
-      + rx4 * esat09 * esac16 + ri3 * esat16 * esac09   &
-      + two * ri1 * esat04 + esac01  )
-
-    ! Loss to accumulation mode, harmonic mean
-
-    qn12 = coagnc0 * coagfm0 / ( coagnc0 + coagfm0 )
-
-    !-----------------------------------------------------------------
-    ! Intermodal coagulation, zeroeth moment, set up for third moment
-    !-----------------------------------------------------------------
     ! Near-continuum form: equation h.10b of whitby et al. (1991)
 
     coagnc3 = knc * dgat3 * (   &
@@ -1357,32 +1420,6 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     qv12 = coagnc3 * coagfm3 / ( coagnc3 + coagfm3 )
 
-    !-----------------------------------------------------
-    ! Intramodal coagulation
-    !-----------------------------------------------------
-    ! aitken mode
-    !--------------
-    ! Near-continuum form: equation h.12a of whitby et al. (1991)
-    coagnc_at = knc * (one + esat08 + a_const * kngat * (esat20 + esat04))
-
-    ! Free-molecular form: equation h.11a of whitby et al. (1991)
-    coagfm_at = kfmat * sqdgat * bm0(n2n) *  ( esat01 + esat25 + two * esat05 )
-
-    ! Harmonic mean
-    qn11 = coagfm_at * coagnc_at / ( coagfm_at + coagnc_at )
-
-    !-------------------
-    ! accumulation mode
-    !-------------------
-    ! Near-continuum form: equation h.12a of whitby et al. (1991)
-    coagnc_ac = knc * (one + esac08 + a_const * kngac * (esac20 + esac04))
-
-    ! Free-molecular form: equation h.11a of whitby et al. (1991)
-    coagfm_ac = kfmac * sqdgac * bm0(n2a) * ( esac01 + esac25 + two * esac05 )
-
-    ! Harmonic mean
-    qn22 = coagfm_ac * coagnc_ac / ( coagfm_ac + coagnc_ac )
-
-end  subroutine getcoags
+end subroutine intermodal_coag_rate_for_3rd_moment
 
 end module modal_aero_coag

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -91,10 +91,10 @@ subroutine mam_coag_1subarea(                                   &
 
       ! Arguments
 
-      real(wp), intent(in) :: deltat                ! timestep used for integrating the coag. equations [s]
-      real(wp), intent(in) :: temp                  ! temperature at layer center [K]
-      real(wp), intent(in) :: pmid                  ! pressure at layer center [Pa]
-      real(wp), intent(in) :: aircon                ! molar concentration of air [kmol/m3]
+      real(wp), intent(in) :: deltat             ! timestep used for integrating the coag. equations [s]
+      real(wp), intent(in) :: temp               ! temperature at layer center [K]
+      real(wp), intent(in) :: pmid               ! pressure at layer center [Pa]
+      real(wp), intent(in) :: aircon             ! molar concentration of air [kmol/m3]
       real(wp), intent(in) :: dgn_a(max_mode)    ! dry geometric mean diameter [m] of size distribution
       real(wp), intent(in) :: dgn_awet(max_mode) ! geometric mean diameter [m] of size distribution
       real(wp), intent(in) :: wetdens(max_mode)  ! interstitial aerosol wet density [kg/m3]
@@ -195,11 +195,11 @@ subroutine mam_coag_num_update( ybetaij0, ybetaii0, ybetajj0, deltat, qnum_bgn, 
       real(wp), intent(in) :: ybetaij0(max_coagpair) ! coag rate coefficient
       real(wp), intent(in) :: ybetaii0(max_coagpair) ! coag rate coefficient
       real(wp), intent(in) :: ybetajj0(max_coagpair) ! coag rate coefficient
-      real(wp), intent(in) :: deltat
+      real(wp), intent(in) :: deltat                 ! timestep [s]
 
-      real(wp), intent(in)    :: qnum_bgn(1:max_mode)  ! beginning values of number mixing ratios
-      real(wp), intent(inout) :: qnum_end(1:max_mode)  ! end values of number mixing ratios
-      real(wp), intent(out)   :: qnum_tavg(1:max_mode) ! time average defined as 0.5*(bgn+end)
+      real(wp), intent(in)    :: qnum_bgn(1:max_mode)  ! beginning values of number mixing ratios [#/kmol-air]
+      real(wp), intent(inout) :: qnum_end(1:max_mode)  ! end values of number mixing ratios [#/kmol-air]
+      real(wp), intent(out)   :: qnum_tavg(1:max_mode) ! time average defined as 0.5*(bgn+end) [#/kmol-air]
 
       ! local variables
       real(wp) :: tmpa, rateij
@@ -245,10 +245,10 @@ subroutine qnum_update_selfcoag( ybetajj0, deltat, qnum_bgn, qnum_end )
 ! Purpose: update the number mixing ratio of a single mode by considering self-coagulation
 !-----------------------------------------------------------------------------------------
 
-    real(wp),intent(in)  :: qnum_bgn   ! qnum (number mixing ratio) start value
+    real(wp),intent(in)  :: qnum_bgn   ! number mixing ratio [#/kmol-air], start value
     real(wp),intent(in)  :: ybetajj0   ! self-coagulation coefficient
-    real(wp),intent(in)  :: deltat     ! timestep length
-    real(wp),intent(out) :: qnum_end   ! qnum (number mixing ratio) end value
+    real(wp),intent(in)  :: deltat     ! timestep length [s]
+    real(wp),intent(out) :: qnum_end   ! number mixing ratio [#/kmol-air], end value
 
     ! Analytical solution
     qnum_end = qnum_bgn / ( 1.0_wp + ybetajj0*deltat*qnum_bgn )
@@ -262,8 +262,8 @@ subroutine qnum_update_self_and_intermodal_coag( rateij, rateii, qnum_bgn, qnum_
 !-----------------------------------------------------------------------------------------
 
     real(wp),intent(in)  :: rateij, rateii  ! inter-modal and self-coagulation rates
-    real(wp),intent(in)  :: qnum_bgn        ! qnum (number mixing ratio) start value
-    real(wp),intent(out) :: qnum_end        ! qnum (number mixing ratio) end value
+    real(wp),intent(in)  :: qnum_bgn        ! number mixing ratio [#/kmol-air], start value
+    real(wp),intent(out) :: qnum_end        ! number mixing ratio [#/kmol-air], end value
 
     real(wp) :: tmpc
 
@@ -405,8 +405,8 @@ subroutine getcoags_wrapper_f(&
 
     ! Arguments 
 
-    real(wp), intent(in) :: airtemp  ! air temperature [ k ]
-    real(wp), intent(in) :: airprs   ! air pressure in [ pa ]
+    real(wp), intent(in) :: airtemp  ! air temperature [K]
+    real(wp), intent(in) :: airprs   ! air pressure [Pa]
 
     real(wp), intent(in) :: dgatk    ! aitken mode geometric mean diameter [m]
     real(wp), intent(in) :: dgacc    ! accumulation mode geometric mean diam [m]
@@ -414,22 +414,22 @@ subroutine getcoags_wrapper_f(&
     real(wp), intent(in) :: sgatk    ! aitken mode geometric standard deviation
     real(wp), intent(in) :: sgacc    ! accumulation mode geometric standard deviation
 
-    real(wp), intent(in) :: xxlsgat  ! natural log of geometric standard
-    real(wp), intent(in) :: xxlsgac  !  deviations
+    real(wp), intent(in) :: xxlsgat  ! natural log of geometric std. dev. of aitken mode
+    real(wp), intent(in) :: xxlsgac  ! natural log of geometric std. dev. of accumulation mode
 
-    real(wp), intent(in) :: pdensat  ! aitken mode particle density [ kg / m**3 ]
-    real(wp), intent(in) :: pdensac  ! accumulation mode density [ kg / m**3 ]
+    real(wp), intent(in) :: pdensat  ! aitken mode particle density [kg/m**3]
+    real(wp), intent(in) :: pdensac  ! accumulation mode density [kg/m**3]
 
     real(wp), intent(out) :: betaij0, betaii0, betajj0, betaij3
 
     ! Local variables and parameters 
 
-    real(wp) :: t0  ! standard surface temperature (15 deg C) [ k ]
+    real(wp) :: t0  ! standard surface temperature (15 deg C) [K]
     real(wp), parameter :: two3 = 2.0_wp/3.0_wp
 
-    real(wp) amu            ! atmospheric dynamic viscosity [ kg/m s ]
+    real(wp) amu            ! atmospheric dynamic viscosity [kg/m s]
     real(wp) sqrt_temp      ! square root of ambient temperature
-    real(wp) lamda          ! mean free path [ m ]
+    real(wp) lamda          ! mean free path [m]
 
 
     ! Near-continnuum regime (independent of mode)
@@ -444,11 +444,11 @@ subroutine getcoags_wrapper_f(&
 
     ! Output from getcoags
 
-    real(wp)  qn11  ! aitken mode intramodal coagulation rate [ m**3/s ] for 0th moment 
-    real(wp)  qn22  ! accum. mode intramodal coagulation rate [ m**3/s ] for 0th moment 
+    real(wp)  qn11  ! aitken mode intramodal coagulation rate [m**3/s] for 0th moment 
+    real(wp)  qn22  ! accum. mode intramodal coagulation rate [m**3/s] for 0th moment 
 
-    real(wp)  qn12  ! aitken to accumulation intermodal coagulation rate [ m**3/s ] for 0th moment
-    real(wp)  qv12  ! aitken to accumulation intermodal coagulation rate [ m**3/s ] for 3rd moment
+    real(wp)  qn12  ! aitken to accumulation intermodal coagulation rate [m**3/s] for 0th moment
+    real(wp)  qv12  ! aitken to accumulation intermodal coagulation rate [m**3/s] for 3rd moment
 
     ! For unit conversion
     real(wp)  dumatk3
@@ -459,17 +459,17 @@ subroutine getcoags_wrapper_f(&
     t0 = tmelt + 15._wp
     sqrt_temp = sqrt( airtemp)
 
-    ! Calculate mean free path [ m ]:
+    ! Calculate mean free path [m]:
     ! 6.6328e-8 is the sea level value given in table i.2.8
     ! on page 10 of u.s. standard atmosphere 1962
 
     lamda = 6.6328e-8_wp * p0 * airtemp  / ( t0 * airprs )
 
-    ! Calculate dynamic viscosity [ kg m**-1 s**-1 ]:
+    ! Calculate dynamic viscosity [kg m**-1 s**-1]:
     ! u.s. standard atmosphere 1962 page 14 expression
     ! for dynamic viscosity is:
     ! dynamic viscosity =  beta * t * sqrt(t) / ( t + s)
-    ! where beta = 1.458e-6 [ kg sec^-1 k**-0.5 ], s = 110.4 [ k ].
+    ! where beta = 1.458e-6 [kg s^-1 K**-0.5], s = 110.4 [K].
 
     amu = 1.458e-6_wp * airtemp * sqrt_temp / ( airtemp + 110.4_wp )
 
@@ -552,7 +552,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     implicit none
 
-    real(wp), intent(in) ::  lamda     ! mean free path [ m ]
+    real(wp), intent(in) ::  lamda     ! mean free path [m]
 
     ! Coefficients for free molecular regime
 
@@ -562,7 +562,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     real(wp), intent(in) ::  knc   ! coefficient for near continnuum regime
 
-    ! Modal geometric mean diameters: [ m ]
+    ! Modal geometric mean diameters: [m]
 
     real(wp), intent(in) :: dgatk          ! aitken mode
     real(wp), intent(in) :: dgacc          ! accumulation mode
@@ -574,8 +574,8 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     ! Natural log of modal geometric standard deviation
 
-    real(wp), intent(in) :: xxlsgat         ! aitken mode
-    real(wp), intent(in) :: xxlsgac         ! accumulation mode
+    real(wp), intent(in) :: xxlsgat        ! aitken mode
+    real(wp), intent(in) :: xxlsgac        ! accumulation mode
 
     ! Coagulation coefficients
     real(wp), intent(out) :: qn11, qn22, qn12, qv12 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -584,7 +584,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     real(wp) :: kngat, kngac
     real(wp),parameter :: one = 1.0_wp, two = 2.0_wp, half = 0.5_wp
-    real(wp),parameter :: a = 1.246_wp
+    real(wp),parameter :: a_const = 1.246_wp
     real(wp),parameter :: two3rds = 2._wp / 3._wp
 
     real(wp) sqrttwo  !  sqrt(two)
@@ -1317,7 +1317,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     ! Near-continuum form:  equation h.10a of whitby et al. (1991)
 
     coagnc0 = knc * (   &
-      two + a * ( kngat * ( esat04 + r2 * esat16 * esac04 )   &
+      two + a_const * ( kngat * ( esat04 + r2 * esat16 * esac04 )   &
       + kngac * ( esac04 + ri2 * esac16 * esat04 ) )   &
       + ( r2 + ri2 ) * esat04 * esac04  )
 
@@ -1339,8 +1339,8 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
 
     coagnc3 = knc * dgat3 * (   &
       two * esat36   &
-      + a * kngat * ( esat16 + r2 * esat04 * esac04 )   &
-      + a * kngac * ( esat36 * esac04 + ri2 * esat64 * esac16 )   &
+      + a_const * kngat * ( esat16 + r2 * esat04 * esac04 )   &
+      + a_const * kngac * ( esat36 * esac04 + ri2 * esat64 * esac16 )   &
       + r2 * esat16 * esac04 + ri2 * esat64 * esac04 )
 
     ! Free-molecular form: equation h.7b of whitby et al. (1991)
@@ -1363,7 +1363,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     ! aitken mode
     !--------------
     ! Near-continuum form: equation h.12a of whitby et al. (1991)
-    coagnc_at = knc * (one + esat08 + a * kngat * (esat20 + esat04))
+    coagnc_at = knc * (one + esat08 + a_const * kngat * (esat20 + esat04))
 
     ! Free-molecular form: equation h.11a of whitby et al. (1991)
     coagfm_at = kfmat * sqdgat * bm0(n2n) *  ( esat01 + esat25 + two * esat05 )
@@ -1375,7 +1375,7 @@ subroutine getcoags( lamda, kfmatac, kfmat, kfmac, knc,           &
     ! accumulation mode
     !-------------------
     ! Near-continuum form: equation h.12a of whitby et al. (1991)
-    coagnc_ac = knc * (one + esac08 + a * kngac * (esac20 + esac04))
+    coagnc_ac = knc * (one + esac08 + a_const * kngac * (esac20 + esac04))
 
     ! Free-molecular form: equation h.11a of whitby et al. (1991)
     coagfm_ac = kfmac * sqdgac * bm0(n2a) * ( esac01 + esac25 + two * esac05 )


### PR DESCRIPTION
The coagulation process in the aerosol microphysics package is refactored. Code changes are mainly in `modal_aero_coag.F90`:

- Subroutine `mam_coag_1subarea` is split into smaller subroutines; the contents not used by MAM4 are removed; many variables names are changed to (hopefully) more self-explanatory ones.
- Unused variables, data blocks, and calculations in subroutines `getcoags_wrapper_f` and `getcoags` are removed.
- The initialization of coagulation pairs in `modal_aero_amicphys:modal_aero_amicphys_init` is wrapped in a new subroutine `set_coagulation_pairs` in `modal_aero_coag.F90`; the contents not used by MAM4 are removed.

Please note that since the subroutine `mam_coag_1subarea` is significantly restructured, the comparison of `modal_aero_coag.F90` provided below by GitHub is not very helpful. To review the changes, it would be easier to simply open the new file in an editor window and read through it.

SMS test passed.
