### PR TITLE
Fixes fast run and build script by removing a space in LD_LIBRARY_PATH for compy

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2446,7 +2446,7 @@
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
     </environment_variables>
     <environment_variables compiler="intel">
-      <env name="LD_LIBRARY_PATH"> /share/apps/intel/oneapi:/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="LD_LIBRARY_PATH">/share/apps/intel/oneapi:/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$ENV{LD_LIBRARY_PATH}</env>
     </environment_variables>
     <environment_variables mpilib="mvapich2">
       <env name="MV2_ENABLE_AFFINITY">0</env>


### PR DESCRIPTION
A space in the LD_LIBRARY_PATH broke the `fast_compile_run.sh`. This PR fixes that and now we can use that script again!