### PR TITLE
Refactor subroutine nucleate_ice_cam_calc in nucleate_ice_cam.F90

### DIFF
--- a/components/eam/src/physics/cam/microp_aero.F90
+++ b/components/eam/src/physics/cam/microp_aero.F90
@@ -383,6 +383,7 @@ subroutine microp_aero_run ( &
    integer :: nmodes 
  
    real(r8), pointer :: state_q(:,:,:)
+   real(r8), pointer :: temperature(:,:)
    real(r8), pointer :: ast(:,:)        
    real(r8), pointer :: alst(:,:)        
    real(r8), pointer :: aist(:,:)        
@@ -465,6 +466,7 @@ subroutine microp_aero_run ( &
 
 
    state_q => state%q
+   temperature => state%t
 
    liqcldf(:ncol,:pver) = alst(:ncol,:pver) 
    icecldf(:ncol,:pver) = aist(:ncol,:pver)
@@ -483,7 +485,7 @@ subroutine microp_aero_run ( &
    ! initialize time-varying parameters
    do k = top_lev, pver
       do i = 1, ncol
-         rho(i,k) = pmid(i,k)/(rair*t(i,k))
+         rho(i,k) = pmid(i,k)/(rair*temperature(i,k))
       end do
    end do
 
@@ -574,7 +576,7 @@ subroutine microp_aero_run ( &
    !ICE Nucleation
 
    call t_startf('nucleate_ice_cam_calc')
-   call nucleate_ice_cam_calc(ncol, lchnk, t, state_q, pmid, &      ! input
+   call nucleate_ice_cam_calc(ncol, lchnk, temperature, state_q, pmid, &      ! input
                               rho, wsubice, ast, dgnum, &           ! input
                               naai, naai_hom)                       ! output
    call t_stopf('nucleate_ice_cam_calc')

--- a/components/eam/src/physics/cam/microp_aero.F90
+++ b/components/eam/src/physics/cam/microp_aero.F90
@@ -451,9 +451,8 @@ subroutine microp_aero_run ( &
 
    call t_startf('microp_aero_run_init')
 
-   ! note for C++ porting, those variables are obtained from pbuf (Fortran MAM code)
-   ! which will not be used in C++ MAM code. It should be ported in
-   ! a different way.
+   ! note for C++ porting, the following variables that are obtained using pbuf
+   ! should be obtained from AD for the previous time step
    itim_old = pbuf_old_tim_idx()
    call pbuf_get_field(pbuf, ast_idx,      ast, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, alst_idx,     alst, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
@@ -462,6 +461,8 @@ subroutine microp_aero_run ( &
    call pbuf_get_field(pbuf, cldo_idx, cldo, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) ) 
    call pbuf_get_field(pbuf, wp2_idx, wp2, start=(/1,1,itim_old/),kount=(/pcols,pverp,1/))  
 
+   ! note for C++ porting, the following variables that are obtained using pbuf
+   ! should be obtained from AD
    call pbuf_get_field(pbuf, npccn_idx, npccn) 
    call rad_cnst_get_info(0, nmodes=nmodes)
    call pbuf_get_field(pbuf, dgnumwet_idx, dgnumwet, start=(/1,1,1/), kount=(/pcols,pver,nmodes/) )

--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -91,7 +91,7 @@ end subroutine nucleati_init
 
 subroutine nucleati(  &
    wbar, tair, pmid, relhum, cldn,      &
-   rhoair, so4_num, dst_num, soot_num,  &
+   rhoair, so4_num, dst_num,            &
    nuci, onihf, oniimm, onidep, onimey, &
    dst3_num)
 
@@ -116,7 +116,6 @@ subroutine nucleati(  &
    real(r8), intent(in) :: rhoair      ! air density [kg/m3]
    real(r8), intent(in) :: so4_num     ! so4 aerosol number [#/cm^3]
    real(r8), intent(in) :: dst_num     ! total dust aerosol number [#/cm^3]
-   real(r8), intent(in) :: soot_num    ! soot (hydrophilic) aerosol number [#/cm^3]
    real(r8), intent(in) :: dst3_num     ! dust aerosol number [#/cm^3]
 
    ! Output Arguments
@@ -133,7 +132,6 @@ subroutine nucleati(  &
    real(r8) :: nimey                     ! nucleated number from deposition nucleation (meyers)
    real(r8) :: n1, ni                    ! nucleated number
    real(r8) :: tc, regm                  ! work variable  
-   real(r8) :: soot_dst3_num
    real(r8) :: wbar1, wbar2
 
    !-------------------------------------------------------------------------------
@@ -144,7 +142,6 @@ subroutine nucleati(  &
 
    ni = 0._r8
    tc = tair - 273.15_r8
-   soot_dst3_num = soot_num + dst3_num
 
    ! initialize
    niimm = 0._r8
@@ -152,11 +149,11 @@ subroutine nucleati(  &
    nihf  = 0._r8
 
 
-   if(so4_num >= 1.0e-10_r8 .and. soot_dst3_num >= 1.0e-10_r8 .and. cldn > 0._r8) then
+   if(so4_num >= 1.0e-10_r8 .and. dst3_num >= 1.0e-10_r8 .and. cldn > 0._r8) then
 
       if((tc <= -35.0_r8) .and. ((relhum*svp_water(tair)/svp_ice(tair)*subgrid) >= 1.2_r8)) then ! use higher RHi threshold
 
-            call calculate_regm_nucleati(wbar1, soot_dst3_num, regm)
+            call calculate_regm_nucleati(wbar1, dst3_num, regm)
 
             ! heterogeneous nucleation only
             if (tc > regm) then
@@ -170,7 +167,7 @@ subroutine nucleati(  &
                   
                else
 
-                  call hetero(tc,wbar2,soot_dst3_num,niimm,nidep)
+                  call hetero(tc,wbar2,dst3_num,niimm,nidep)
                   nihf=0._r8
                   n1=niimm+nidep
 
@@ -197,7 +194,7 @@ subroutine nucleati(  &
                else
 
                   call hf(regm-5._r8,wbar1,relhum,so4_num,nihf)
-                  call hetero(regm,wbar2,soot_dst3_num,niimm,nidep)
+                  call hetero(regm,wbar2,dst3_num,niimm,nidep)
 
                   if (nihf <= (niimm+nidep)) then
                      n1 = nihf

--- a/components/eam/src/physics/cam/nucleate_ice.F90
+++ b/components/eam/src/physics/cam/nucleate_ice.F90
@@ -91,9 +91,8 @@ end subroutine nucleati_init
 
 subroutine nucleati(  &
    wbar, tair, pmid, relhum, cldn,      &
-   rhoair, so4_num, dst_num,            &
-   nuci, onihf, oniimm, onidep, onimey, &
-   dst3_num)
+   rhoair, so4_num, dst3_num,  &
+   nuci, onihf, oniimm, onidep, onimey)
 
    !---------------------------------------------------------------
    ! Purpose:
@@ -115,7 +114,6 @@ subroutine nucleati(  &
    real(r8), intent(in) :: cldn        ! new value of cloud fraction    [fraction]
    real(r8), intent(in) :: rhoair      ! air density [kg/m3]
    real(r8), intent(in) :: so4_num     ! so4 aerosol number [#/cm^3]
-   real(r8), intent(in) :: dst_num     ! total dust aerosol number [#/cm^3]
    real(r8), intent(in) :: dst3_num     ! dust aerosol number [#/cm^3]
 
    ! Output Arguments

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -372,9 +372,7 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, wsubi, pbuf
    real(r8) :: coarse_pom(pcols,pver)   ! mass m.r. of coarse pom
    real(r8) :: coarse_soa(pcols,pver)   ! mass m.r. of coarse soa 
 
-   real(r8), pointer :: aer_mmr(:,:)    ! aerosol mass mixing ratio
    real(r8), pointer :: dgnum(:,:,:)    ! mode dry radius
-
    real(r8), pointer :: ast(:,:)
    real(r8) :: icecldf(pcols,pver)  ! ice cloud fraction
 
@@ -388,8 +386,8 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, wsubi, pbuf
    real(r8) :: icldm(pcols,pver)   ! ice cloud fraction
 
    real(r8) :: so4_num                               ! so4 aerosol number [#/cm^3]
-   real(r8) :: dst3_num                              ! dust aerosol number (#/cm^3)
-   real(r8) :: dst_num                               ! total dust aerosol number (#/cm^3)
+   real(r8) :: dst3_num                              ! dust aerosol number [#/cm^3]
+   real(r8) :: dst_num                               ! total dust aerosol number [#/cm^3]
    real(r8) :: wght
    real(r8) :: dmc
    real(r8) :: ssmc

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -346,7 +346,7 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, rho, wsubi,
    integer, intent(in) :: ncol
    integer, intent(in) :: lchnk
    real(r8), intent(in) :: temperature(:,:)     ! input temperature [K]
-   real(r8), intent(in) :: q(:,:,:)             ! input mixing ratio for all water and chem species
+   real(r8), intent(in) :: q(:,:,:)             ! input mixing ratio for all water and chem species [#/kg,kg/kg]
    real(r8), intent(in) :: pmid(:,:)            ! pressure at layer midpoints [pa]
    real(r8), intent(in) :: rho(:,:)             ! air density [kg/m^3]
    real(r8),                    intent(in)    :: wsubi(:,:)   ! updraft velocity for ice nucleation [m/s]  
@@ -365,7 +365,7 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, rho, wsubi,
    integer :: itim_old
    integer :: i, k, m
 
-   real(r8) :: qn(pcols,pver)
+   real(r8) :: qn(pcols,pver)           ! water vapor mixing ratio [kg/kg]
    real(r8) :: num_aitken(pcols,pver)   ! number m.r. of aitken mode [#/kg]
    real(r8) :: num_coarse(pcols,pver)   ! number m.r. of coarse mode [#/kg]
    real(r8) :: coarse_dust(pcols,pver)  ! mass m.r. of coarse dust [kg/kg]
@@ -388,14 +388,14 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, rho, wsubi,
    real(r8) :: so4_num                  ! so4 aerosol number [#/cm^3]
    real(r8) :: dst3_num                 ! dust aerosol number [#/cm^3]
    real(r8) :: dst_num                  ! total dust aerosol number [#/cm^3]
-   real(r8) :: wght
-   real(r8) :: dmc
-   real(r8) :: ssmc
-   real(r8) :: so4mc
-   real(r8) :: mommc
-   real(r8) :: bcmc
-   real(r8) :: pommc
-   real(r8) :: soamc
+   real(r8) :: wght                     ! mass weight [unitless]
+   real(r8) :: dmc                      ! dust mass concentration [kg/m^3]
+   real(r8) :: ssmc                     ! sea salt mass concentration [kg/m^3]
+   real(r8) :: so4mc                    ! sulfate mass concentration [kg/m^3]
+   real(r8) :: mommc                    ! marine organic mass concentration [kg/m^3]
+   real(r8) :: bcmc                     ! black carbon mass concentration [kg/m^3]
+   real(r8) :: pommc                    ! primary organic carbon mass concentration [kg/m^3]
+   real(r8) :: soamc                    ! secondary organic carbon mass concentration [kg/m^3]
 
    ! history output for ice nucleation
    real(r8) :: nihf(pcols,pver)  !output number conc of ice nuclei due to heterogenous freezing [1/m3]
@@ -407,7 +407,7 @@ subroutine nucleate_ice_cam_calc( ncol, lchnk, temperature, q, pmid, rho, wsubi,
 
    !-------------------------------------------------------------------------------
 
-   ! note for converting to C++
+   ! note for C++ porting
    ! read ast, dgnum, naai, naai_hom from pbuf
    ! will need to change according to how pbuf variables are stored in C++ structure
    itim_old = pbuf_old_tim_idx()


### PR DESCRIPTION
This PR refactors subroutine nulceate_ice_cam_calc in nucleate_ice_cam.F90
Mainly changed the way for retrieving aerosol concentrations. Using indexes from modal_aero_data instead of rad_cnst_get_aer_mmr

Remove unused code in microp_aero.F90 for further refactoring of ice nucleation code