### PR TITLE
add outfld back in modal_aero_convproc.F90

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2132,6 +2132,7 @@ do_lphase2_conditional: &
             dp_frac, icwmrdp, rprddp, evapcdp,                & ! in
             sh_frac, icwmrsh, rprdsh, evapcsh,                & ! in
             dlf, dlf2, cmfmc2, sh_e_ed_ratio,                 & ! in
+            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr,           & ! in
             mu, md, du, eu, ed, dp, jt, maxg,                 & ! in
             ideep, lengath,  species_class,                   & ! in
             ptend, aerdepwetis                                ) ! inout

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -677,9 +677,9 @@ subroutine ma_convproc_sh_intr(                 &
                      xx_mfup_max, xx_wcldbase, xx_kcldbase           ) ! out
 
     ! output diagnostics fields
-    call outfld( 'DP_MFUP_MAX', xx_mfup_max, pcols, state%lchnk )
-    call outfld( 'DP_WCLDBASE', xx_wcldbase, pcols, state%lchnk )
-    call outfld( 'DP_KCLDBASE', xx_kcldbase, pcols, state%lchnk )
+    call outfld( 'SH_MFUP_MAX', xx_mfup_max, pcols, state%lchnk )
+    call outfld( 'SH_WCLDBASE', xx_wcldbase, pcols, state%lchnk )
+    call outfld( 'SH_KCLDBASE', xx_kcldbase, pcols, state%lchnk )
 
 end subroutine ma_convproc_sh_intr
 


### PR DESCRIPTION
Add the outfld code removed before back for BFB test with history files.
included variables: aerdepwetis, sflxic, sflxec, sflxid, sflxed, xx_mfup_max, xx_wcldbase, xx_kcldbase
will need to compare with history files to test this PR as the regular tests do not depend on these variables. Balwinder, can you do that?
One note for the diagnostic variables is that xx_kcldbase is filled with index kk but defined as real. I am not sure if this will cause any problem.