### PR TITLE
final clean up of modal_aero_convproc.F90

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -188,7 +188,6 @@ contains
     use mo_chem_utls,    only: get_rxt_ndx, get_spc_ndx
     use modal_aero_data, only: cnst_name_cw
     use modal_aero_initialize_data, only: modal_aero_initialize
-    use modal_aero_convproc, only: deepconv_wetdep_history
     use rad_constituents,           only: rad_cnst_get_info
     use dust_model,      only: dust_init, dust_names, dust_active, dust_nbin, dust_nnum
     use seasalt_model,   only: seasalt_init, seasalt_names, seasalt_active,seasalt_nbin
@@ -513,12 +512,12 @@ contains
                horiz_only,  'A','kg/m2/s','Wet deposition flux (precip evap, convective) at surface')  !RCE
           call addfld (trim(wetdep_list(m))//'SFSES', &
                horiz_only,  'A','kg/m2/s','Wet deposition flux (precip evap, stratiform) at surface')  !RCE
-          if (convproc_do_aer .and. deepconv_wetdep_history) then
+          if (convproc_do_aer) then
           call addfld (trim(wetdep_list(m))//'SFSED', &
                horiz_only,  'A','kg/m2/s','Wet deposition flux (precip evap, deep convective) at surface')  !RCE
           endif
        endif
-       if (convproc_do_aer .and. deepconv_wetdep_history) then
+       if (convproc_do_aer) then
                     call addfld (trim(wetdep_list(m))//'SFSID', &
                horiz_only,  'A','kg/m2/s','Wet deposition flux (incloud, deep convective) at surface')  !RCE
           call addfld (trim(wetdep_list(m))//'SFSBD', &
@@ -1311,7 +1310,7 @@ contains
     use modal_aero_data
     use modal_aero_calcsize,   only: modal_aero_calcsize_sub
     use modal_aero_wateruptake,only: modal_aero_wateruptake_dr
-    use modal_aero_convproc,   only: deepconv_wetdep_history, ma_convproc_intr
+    use modal_aero_convproc,   only: ma_convproc_intr
     use mo_constants,          only: pi
     use infnan,                only: nan, assignment(=)
 
@@ -1898,8 +1897,7 @@ lphase_jnmw_conditional: &
                 ! only do this for interstitial aerosol, because conv clouds to not
                 !    affect the stratiform-cloudborne aerosol
                 if ( convproc_do_aer ) then
-                   if ( deepconv_wetdep_history ) then
-                      do i = 1, ncol
+                   do i = 1, ncol
                          tmp_precdp = max( rprddpsum(i),  1.0e-35_r8 )
                          tmp_precsh = max( rprdshsum(i),  1.0e-35_r8 )
                          tmp_evapdp = max( evapcdpsum(i), 0.1e-35_r8 )
@@ -1921,11 +1919,8 @@ lphase_jnmw_conditional: &
                          else
                             sflxecdp(i) = 0.0_r8
                          end if
-                      end do
-                      call outfld( trim(cnst_name(mm))//'SFSBD', sflxbcdp, pcols, lchnk)
-                   else
-                      sflxecdp(1:ncol) = 0.0_r8
-                   end if
+                   end do
+                   call outfld( trim(cnst_name(mm))//'SFSBD', sflxbcdp, pcols, lchnk)
                    ! when ma_convproc_intr is used, convective in-cloud wet removal is done there
                    ! the convective (total and deep) precip-evap-resuspension includes in- and below-cloud
                    ! contributions, so pass the below-cloud contribution to ma_convproc_intr

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -53,6 +53,10 @@ module modal_aero_convproc
 ! module data
    real(r8) :: hund_ovr_g  ! = 100.0_r8/gravit, calculated once and used frequently
    real(r8), parameter :: mbsth = 1.e-15 ! threshold below which we treat the mass fluxes as zero [mb/s]
+   real(r8), parameter :: clw_cut = 1.0e-6      ! cutoff value of cloud water for doing updraft [kg/kg]
+                ! Skip levels where icwmr(icol,k) <= clw_cut (=1.0e-6) to
+                ! eliminate occasional very small icwmr values from the ZM
+                ! module
    logical  :: convproc_do_gas, convproc_do_aer
 
 !=========================================================================================
@@ -1794,9 +1798,6 @@ jtsub_loop_main_aa: &
 
    logical      :: do_act_this_lev      ! flag for doing activation at current level
    integer      :: kp1                  ! kk + 1
-   real(r8), parameter :: clw_cut = 1.0e-6      ! cutoff value of cloud water for doing updraft [kg/kg]
-                ! Skip levels where icwmr(icol,k) <= clw_cut (=1.0e-6) to
-                ! eliminate occasional very small icwmr values from the ZM module
 
    ! initiate variables
    do_act_this_lev = .false.
@@ -2110,9 +2111,6 @@ jtsub_loop_main_aa: &
    real(r8)     :: expcdtm1     ! exp(cdt) - 1 [unitless]
    real(r8)     :: half_cld     ! 0.5 * cldfrac [fraction]
 
-   real(r8), parameter :: clw_cut = 1.0e-6      ! cutoff value of cloud water for doing updraft [kg/kg]
-                ! Skip levels where icwmr(icol,k) <= clw_cut (=1.0e-6) to
-                ! eliminate occasional very small icwmr values from the ZM module
 
    cdt = 0.0_r8
    if ((icwmr(icol,kk) > clw_cut) .and. (rprd(icol,kk) > 0.0)) then

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -2229,6 +2229,10 @@ jtsub_loop_main_aa: &
             endif
             netflux = fluxin - fluxout
 
+            ! note for C++ refactoring:
+            ! I was trying to separate dconudt_activa and dconudt_wetdep out
+            ! into a subroutine, but for some reason it doesn't give consistent
+            ! dcondt values. have to leave them here.   Shuaiqi Tang, 2022
             netsrce = fa_u_dp*(dconudt_activa(icnst,kk) + dconudt_wetdep(icnst,kk))
             dcondt(icnst,kk) = (netflux+netsrce)/dpdry_i(kk)
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -88,8 +88,6 @@ subroutine ma_convproc_init
   implicit none
 
   logical :: history_aerosol      ! Output the MAM aerosol tendencies
-  logical :: resus_fix
-  character(len=100) :: msg
 
 ! 
 ! Add history fields
@@ -119,22 +117,21 @@ subroutine ma_convproc_init
        call add_default( 'DP_MFUP_MAX', 1, ' ' )
        call add_default( 'DP_WCLDBASE', 1, ' ' )
        call add_default( 'DP_KCLDBASE', 1, ' ' )
-    end if
+    endif
 
 !
 ! Print control variable settings
 !
-   if ( .not. masterproc ) return
-
-   write(*,'(a,l12)')     'ma_convproc_init - convproc_do_aer               = ', &
-      convproc_do_aer
-   write(*,'(a,l12)')     'ma_convproc_init - convproc_do_gas               = ', &
-      convproc_do_gas
-   write(*,'(a,1pe12.4)') 'ma_convproc_init - activate_smaxmax              = ', &
-      activate_smaxmax
-   write(*,'(a,1pe12.4)') 'ma_convproc_init - factor_reduce_actfrac         = ', &
-      factor_reduce_actfrac
-
+   if ( masterproc ) then 
+           write(*,'(a,l12)')     'ma_convproc_init - convproc_do_aer               = ', &
+                 convproc_do_aer
+           write(*,'(a,l12)')     'ma_convproc_init - convproc_do_gas               = ', &
+                 convproc_do_gas
+           write(*,'(a,1pe12.4)') 'ma_convproc_init - activate_smaxmax              = ', &
+                 activate_smaxmax
+           write(*,'(a,1pe12.4)') 'ma_convproc_init - factor_reduce_actfrac         = ', &
+                 factor_reduce_actfrac
+   endif
 
    return
 end subroutine ma_convproc_init

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -17,7 +17,7 @@ module modal_aero_convproc
 
    use shr_kind_mod, only: r8=>shr_kind_r8
    use physconst,    only: gravit                              
-   use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
+   use ppgrid,       only: pver, pcols, pverp
    use cam_history,  only: outfld, addfld, horiz_only, add_default
    use cam_logfile,  only: iulog
    use cam_abortutils, only: endrun
@@ -38,11 +38,6 @@ module modal_aero_convproc
 !
 ! module data
 !
-   !deepconv_wetdep_history variable controls history output of additonal deep-convection wet deposition fields 
-   !(in addition to the normal fields for total-convection wet deposition)
-   logical, parameter, public :: deepconv_wetdep_history = .true.
-   logical, parameter :: use_cwaer_for_activate_maxsat = .false.
-   logical, parameter :: apply_convproc_tend_to_ptend = .true.
 
    real(r8) :: hund_ovr_g  != 100.0_r8/gravit
 !  used with zm_conv mass fluxes and delta-p
@@ -135,10 +130,6 @@ subroutine ma_convproc_init
       convproc_do_aer
    write(*,'(a,l12)')     'ma_convproc_init - convproc_do_gas               = ', &
       convproc_do_gas
-   write(*,'(a,l12)')     'ma_convproc_init - use_cwaer_for_activate_maxsat = ', &
-      use_cwaer_for_activate_maxsat
-   write(*,'(a,l12)')     'ma_convproc_init - apply_convproc_tend_to_ptend  = ', &
-      apply_convproc_tend_to_ptend
    write(*,'(a,1pe12.4)') 'ma_convproc_init - activate_smaxmax              = ', &
       activate_smaxmax
    write(*,'(a,1pe12.4)') 'ma_convproc_init - factor_reduce_actfrac         = ', &
@@ -373,11 +364,8 @@ subroutine ma_convproc_intr( state, ztodt,                          & ! in
         call outfld( trim(cnst_name(l))//'SFWET', aerdepwetis(:,l), pcols, lchnk)
         call outfld( trim(cnst_name(l))//'SFSIC', sflxic(:,l), pcols, lchnk )
         call outfld( trim(cnst_name(l))//'SFSEC', sflxec(:,l), pcols, lchnk )
-
-        if ( deepconv_wetdep_history ) then
-           call outfld( trim(cnst_name(l))//'SFSID', sflxid(:,l), pcols, lchnk )
-           call outfld( trim(cnst_name(l))//'SFSED', sflxed(:,l), pcols, lchnk )
-        endif
+        call outfld( trim(cnst_name(l))//'SFSID', sflxid(:,l), pcols, lchnk )
+        call outfld( trim(cnst_name(l))//'SFSED', sflxed(:,l), pcols, lchnk )
      enddo ! ll
      enddo ! n
   endif

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -1212,7 +1212,7 @@ jtsub_loop_main_aa: &
                                     dcondt_resusp                       ) ! out
 
         ! calculate new column-tendency variables
-        call compute_tendency_resusp_evap(                              &
+        call compute_column_tendency(                                   &
                 doconvproc_extd, ktop,          kbot_prevap,   dpdry_i, & ! in
                 dcondt_resusp,  dcondt_prevap,  dcondt_prevap_hist,     & ! in
                 dconudt_activa, dconudt_wetdep, fa_u,                   & ! in
@@ -2628,7 +2628,7 @@ jtsub_loop_main_aa: &
 
 
 !=========================================================================================
-   subroutine compute_tendency_resusp_evap(                             &
+   subroutine compute_column_tendency(                                  &
                 doconvproc_extd, ktop,          kbot_prevap,  dpdry_i,  & ! in
                 dcondt_resusp,  dcondt_prevap,  dcondt_prevap_hist,     & ! in
                 dconudt_activa, dconudt_wetdep, fa_u,                   & ! in
@@ -2686,7 +2686,7 @@ jtsub_loop_main_aa: &
          enddo
       endif
    enddo
-   end subroutine compute_tendency_resusp_evap
+   end subroutine compute_column_tendency
 
 !====================================================================================
    subroutine update_tendency_final(                            &


### PR DESCRIPTION
This is a final clean up of modal_aero_convproc.F90 file, after refactoring the individual subroutines in it. I made the following changes:
1. re-organize the order of subroutines
2. refactor and rename a few subroutines to make more logical sense
3. move all "use" statements to the beginning of the module
4. move all parameters that only used once into the subroutine using them.
5. rename all state%xx and ptend%xx in subroutines except interface.
6. rename some variables
