### PR TITLE
Refactor get_aer_num in hetfrz_classnuc_cam.F90

### DIFF
--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -567,18 +567,18 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    real(r8), pointer :: ptr2d(:,:)
 
-   real(r8) :: fn(hetfrz_aer_nspec)
-   real(r8) :: awcam(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: awfacm(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: hetraer(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: dstcoat(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: total_interstitial_aer_num(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: total_cloudborne_aer_num(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: total_aer_num(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: coated_aer_num(pcols,pver,hetfrz_aer_nspec)
-   real(r8) :: uncoated_aer_num(pcols,pver,hetfrz_aer_nspec)
+   real(r8) :: fn(3)
+   real(r8) :: awcam(pcols,pver,3)
+   real(r8) :: awfacm(pcols,pver,3)
+   real(r8) :: hetraer(pcols,pver,3)
+   real(r8) :: dstcoat(pcols,pver,3)
+   real(r8) :: total_interstitial_aer_num(pcols,pver,3)
+   real(r8) :: total_cloudborne_aer_num(pcols,pver,3)
+   real(r8) :: total_aer_num(pcols,pver,3)
+   real(r8) :: coated_aer_num(pcols,pver,3)
+   real(r8) :: uncoated_aer_num(pcols,pver,3)
 
-   real(r8) :: fn_cloudborne_aer_num(pcols,pver,hetfrz_aer_nspec)
+   real(r8) :: fn_cloudborne_aer_num(pcols,pver,3)
 
 
    real(r8) :: con1, r3lx, supersatice
@@ -684,24 +684,25 @@ subroutine hetfrz_classnuc_cam_calc( &
    do kk = top_lev, pver
       do icol = 1, ncol
          call calculate_interstitial_aer_num(ncnst, aer(icol,kk,:,lchnk_zb), & ! in 
-                                             total_interstitial_aer_num(icol,kk,:))  ! out
+                                             total_interstitial_aer_num(icol,kk,:)) ! out
 
-         call calculate_cloudborne_aer_num(ncnst, aer_cb(icol,kk,:,lchnk_zb), &  ! in
-                                           total_cloudborne_aer_num(icol,kk,:))        ! out                                                                                        
+         call calculate_cloudborne_aer_num(ncnst, aer_cb(icol,kk,:,lchnk_zb), & ! in
+                                           total_cloudborne_aer_num(icol,kk,:)) ! out 
 
          call calculate_mass_mean_radius(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in
                                          total_interstitial_aer_num(icol,kk,:), &  ! in
-                                         hetraer(icol,kk,:))                       ! out
+                                         hetraer(icol,kk,:)) ! out
 
-         call calculate_coated_fraction(ncnst, aer(icol,kk,:,lchnk_zb), rho(icol,kk), &                                ! in
+
+         call calculate_coated_fraction(ncnst, aer(icol,kk,:,lchnk_zb), rho(icol,kk), &                                      ! in
                                         total_interstitial_aer_num(icol,kk,:), total_cloudborne_aer_num(icol,kk,:), &        ! in
-                                        hetraer(icol,kk,:), &                                                                ! in 
-                                        total_aer_num(icol,kk,:), coated_aer_num(icol,kk,:), uncoated_aer_num(icol,kk,:), &  ! out      
-                                        dstcoat(icol,kk,:), na500(icol,kk), tot_na500(icol,kk))                              ! out     
+                                        hetraer(icol,kk,:), &                                                                ! in
+                                        total_aer_num(icol,kk,:), coated_aer_num(icol,kk,:), uncoated_aer_num(icol,kk,:), &  ! out
+                                        dstcoat(icol,kk,:), na500(icol,kk), tot_na500(icol,kk))                              ! out
 
          call calculate_water_activity(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in        
-                                       total_interstitial_aer_num(icol,kk,:), &  ! in        
-                                       awcam(icol,kk,:), awfacm(icol,kk,:))      ! out
+                                       total_interstitial_aer_num(icol,kk,:), & ! in        
+                                       awcam(icol,kk,:), awfacm(icol,kk,:)) ! out
 
          fn_cloudborne_aer_num(icol,kk,1) = total_aer_num(icol,kk,1)*factnum(icol,kk,mode_accum_idx)  ! bc
          fn_cloudborne_aer_num(icol,kk,2) = total_aer_num(icol,kk,2)*factnum(icol,kk,mode_accum_idx)  ! dst_a1
@@ -807,7 +808,7 @@ subroutine hetfrz_classnuc_cam_calc( &
          nnudep_bc(icol,kk) = frzbcdep(icol,kk)*1.0e6_r8*ast(icol,kk)
 
          nnuccc_dst(icol,kk) = frzduimm(icol,kk)*1.0e6_r8*ast(icol,kk)
-         nnucct_dst(icol,kk) = frzducnt(icol,kk)*1.0e6_r8*ast(icol,kk)     
+         nnucct_dst(icol,kk) = frzducnt(icol,kk)*1.0e6_r8*ast(icol,kk)
          nnudep_dst(icol,kk) = frzdudep(icol,kk)*1.0e6_r8*ast(icol,kk)
 
          niimm_bc(icol,kk) = frzbcimm(icol,kk)*1.0e6_r8*deltatin
@@ -901,7 +902,7 @@ subroutine calculate_interstitial_aer_num(ncnst, aer, &
    ! calculate interstial aerosol concentrations for
    ! BC and dust 
    !***************************************************
-
+     
    ! input
    integer,  intent(in) :: ncnst
    real(r8), intent(in) :: aer(ncnst)  ! interstitial aerosol concentrations [kg/m^3]
@@ -909,35 +910,43 @@ subroutine calculate_interstitial_aer_num(ncnst, aer, &
    ! output
    real(r8), intent(out) :: total_interstitial_aer_num(hetfrz_aer_nspec) ! interstitial concentrations of BC and dust [#/cm^3]
 
-
    ! local variables
    real(r8), parameter :: bc_kg_to_num   = 4.669152e+17_r8    ! fixed ratio converting BC mass to number (based on BC emission) [#/kg]
    real(r8), parameter :: dst1_kg_to_num = 3.484e+15_r8       ! fixed ratio converting accum mode dust mass to number [#/kg]
 
-   real(r8) :: dmc                  ! dust mass concentration [kg/m^3]
-   real(r8) :: aermc_coarse_total   ! total aerosol mass concentration in the  coarse mode [kg/m^3] 
+   real(r8) :: bc_num, dst1_num, dst3_num
 
+   real(r8) :: dmc,ssmc                  ! dust mass concentration [kg/m^3]
+   real(r8) :: bcmc, pommc, soamc, mommc
+   real(r8) :: aermc_coarse_total   ! total aerosol mass concentration in the coarse mode [kg/m^3]
 
    total_interstitial_aer_num = 0.0_r8
+   dst3_num = 0.0_r8
 
-   total_interstitial_aer_num(1) = aer(bc_accum) * bc_kg_to_num * num_m3_to_cm3 ! #/cm^3
-   total_interstitial_aer_num(1) = total_interstitial_aer_num(1) + aer(bc_pcarbon) * bc_kg_to_num * num_m3_to_cm3
+   bc_num = aer(bc_accum) * bc_kg_to_num * num_m3_to_cm3 ! #/cm^3
+   bc_num = bc_num + aer(bc_pcarbon) * bc_kg_to_num * num_m3_to_cm3
 
-   total_interstitial_aer_num(2) = aer(dst_accum) * dst1_kg_to_num * num_m3_to_cm3 ! #/cm^3, dust # in accumulation mode
+   dst1_num = aer(dst_accum) * dst1_kg_to_num * num_m3_to_cm3 ! #/cm^3, dust # in accumulation mode
 
 
-   aermc_coarse_total = aer(dst_coarse) + aer(ncl_coarse) + aer(mom_coarse) + &
-                        aer(bc_coarse)  + aer(pom_coarse) + aer(soa_coarse)
-
-   dmc = aer(dst_coarse)
+   dmc   = aer(dst_coarse)
+   ssmc  = aer(ncl_coarse)
+   mommc = aer(mom_coarse)
+   bcmc  = aer(bc_coarse)
+   pommc = aer(pom_coarse)
+   soamc = aer(soa_coarse)
 
    if (dmc > 0._r8 ) then
-      total_interstitial_aer_num(3) = dmc/aermc_coarse_total * aer(num_coarse) * num_m3_to_cm3 ! #/cm^3
+      dst3_num = dmc/(ssmc+dmc+bcmc+pommc+soamc+mommc) * aer(num_coarse) * num_m3_to_cm3 ! #/cm^3
    endif
 
-end subroutine calculate_interstitial_aer_num                                                                                                                        
+   total_interstitial_aer_num(1) = bc_num
+   total_interstitial_aer_num(2) = dst1_num
+   total_interstitial_aer_num(3) = dst3_num
 
-!====================================================================================================                                                                               
+end subroutine calculate_interstitial_aer_num 
+
+!====================================================================================================
 
 subroutine calculate_cloudborne_aer_num(ncnst, aer_cb, &
                                         total_cloudborne_aer_num)
@@ -956,42 +965,54 @@ subroutine calculate_cloudborne_aer_num(ncnst, aer_cb, &
 
 
    ! local variables
-   real(r8) :: as_du                 ! dust mass concentration in the fine mode [kg/m^3]   
-   real(r8) :: as_bc                 ! BC mass concentration in the fine mode [kg/m^3]
-   real(r8) :: dmc_imm               ! dust mass concentration in the coarse mode [kg/m^3]           
-   real(r8) :: aermc_accum_total     ! total aerosol mass concentration in the fine mode [kg/m^3]            
-   real(r8) :: aermc_coarse_total    ! total aerosol mass concentration in the coarse mode [kg/m^3]
+   real(r8) :: bc_num_imm, dst1_num_imm, dst3_num_imm
+   real(r8) :: as_du, as_ss          ! dust, seasalt mass concentration in the fine mode [kg/m^3]   
+   real(r8) :: as_bc, as_pom, as_soa ! BC, POM, SOA mass concentration in the fine mode [kg/m^3]
+   real(r8) :: as_so4, as_mom        ! sulfate, MOA mass concentration in the fine mode [kg/m^3]
+   real(r8) :: dmc_imm, ssmc_imm     ! dust, seasalt mass concentration in the coarse mode [kg/m^3]           
+   real(r8) :: bcmc_imm, pommc_imm, soamc_imm, mommc_imm ! BC, POM, SOA, MOA mass concentration in the coarse mode [kg/m^3]
 
    total_cloudborne_aer_num = 0.0_r8
 
-   as_du = aer_cb(dst_accum)
-   as_bc = aer_cb(bc_accum)
-   
-   aermc_accum_total = aer_cb(so4_accum) + aer_cb(bc_accum)  + aer_cb(pom_accum) + &
-                       aer_cb(soa_accum) + aer_cb(ncl_accum) + aer_cb(dst_accum) + &
-                       aer_cb(mom_accum)
-  
+   bc_num_imm   = 0.0_r8
+   dst1_num_imm = 0.0_r8
+   dst3_num_imm = 0.0_r8
+
+   as_du  = aer_cb(dst_accum)
+   as_ss  = aer_cb(ncl_accum)
+   as_so4 = aer_cb(so4_accum)
+   as_bc  = aer_cb(bc_accum)
+   as_pom = aer_cb(pom_accum)
+   as_soa = aer_cb(soa_accum)
+   as_mom = aer_cb(mom_accum)
+
    if (as_bc > 0._r8) then
-      total_cloudborne_aer_num(1) = as_bc/aermc_accum_total * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
+      bc_num_imm = as_bc/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom) * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
    endif
 
    if (as_du > 0._r8) then
-      total_cloudborne_aer_num(2) = as_du/aermc_accum_total * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
+      dst1_num_imm = as_du/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom) * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
    endif
 
-
-   dmc_imm = aer_cb(dst_coarse)
-
-   aermc_coarse_total = aer_cb(ncl_coarse) + aer_cb(dst_coarse) + aer_cb(bc_coarse) + &
-                        aer_cb(pom_coarse) + aer_cb(soa_coarse) + aer_cb(mom_coarse)
+   dmc_imm   = aer_cb(dst_coarse)
+   ssmc_imm  = aer_cb(ncl_coarse)
+   mommc_imm = aer_cb(mom_coarse)
+   bcmc_imm  = aer_cb(bc_coarse)
+   pommc_imm = aer_cb(pom_coarse)
+   soamc_imm = aer_cb(soa_coarse)
 
    if (dmc_imm > 0._r8) then
-      total_cloudborne_aer_num(3) = dmc_imm/aermc_coarse_total * aer_cb(num_coarse) * num_m3_to_cm3 ! #/cm^3
+      dst3_num_imm = dmc_imm/(ssmc_imm+dmc_imm+bcmc_imm+pommc_imm+soamc_imm+mommc_imm) * aer_cb(num_coarse) * num_m3_to_cm3 ! #/cm^3
    endif
 
-end subroutine calculate_cloudborne_aer_num                                                                                                                                    
+   total_cloudborne_aer_num(1) = bc_num_imm
+   total_cloudborne_aer_num(2) = dst1_num_imm
+   total_cloudborne_aer_num(3) = dst3_num_imm
 
-!====================================================================================================                                                                                                                                      
+end subroutine calculate_cloudborne_aer_num
+
+!====================================================================================================
+
 subroutine calculate_mass_mean_radius(ncnst, aer, &
                                       total_interstitial_aer_num, &
                                       hetraer)
@@ -1010,84 +1031,71 @@ subroutine calculate_mass_mean_radius(ncnst, aer, &
 
    ! local variables
    real(r8) :: bc_num, dst1_num, dst3_num                ! number concentration [#/cm^3]
+   real(r8) :: r_bc, r_dust_a1, r_dust_a3
    real(r8), parameter :: aermc_min_threshold  = 1.0e-30_r8
    real(r8), parameter :: aernum_min_threshold = 1.0e-3_r8
    real(r8), parameter :: r_bc_prescribed = 0.067e-6_r8
    real(r8), parameter :: r_dust_a1_prescribed = 0.258e-6_r8
    real(r8), parameter :: r_dust_a3_prescribed = 1.576e-6_r8
 
+   hetraer = 0.0_r8
+
    bc_num   = total_interstitial_aer_num(1)
    dst1_num = total_interstitial_aer_num(2)
    dst3_num = total_interstitial_aer_num(3)
 
-   ! Initialize hetraer with prescribed radius
-   hetraer(1) = r_bc_prescribed
-   hetraer(2) = r_dust_a1_prescribed
-   hetraer(3) = r_dust_a3_prescribed
+   ! Initialize hetraer with prescribed radius 
+   hetraer(1) = 0.067e-6_r8
+   hetraer(2) = 0.258e-6_r8
+   hetraer(3) = 1.576e-6_r8
 
    ! BC
    if ((aer(bc_accum)+aer(bc_pcarbon))*1.0e-3_r8 > aermc_min_threshold .and. bc_num > aernum_min_threshold) then
-      hetraer(1) = get_aer_radius(specdens_bc, aer(bc_accum)+aer(bc_pcarbon), bc_num*num_cm3_to_m3)
+      hetraer(1) = (3._r8/(4*pi*specdens_bc)*(aer(bc_accum)+aer(bc_pcarbon))/(bc_num*1.0e6_r8))**(1._r8/3._r8)
    endif
 
    ! fine dust a1
    if (aer(dst_accum)*1.0e-3_r8 > aermc_min_threshold .and. dst1_num > aernum_min_threshold) then
-      hetraer(2) = get_aer_radius(specdens_dust, aer(dst_accum), dst1_num*num_cm3_to_m3)
+      hetraer(2) = (3._r8/(4*pi*specdens_dust)*aer(dst_accum)/(dst1_num*1.0e6_r8))**(1._r8/3._r8)
    endif
 
    ! coarse dust a3
    if (aer(dst_coarse)*1.0e-3_r8 > aermc_min_threshold .and. dst3_num > aernum_min_threshold) then
-      hetraer(3) = get_aer_radius(specdens_dust, aer(dst_coarse), dst3_num*num_cm3_to_m3)
+      hetraer(3) = (3._r8/(4*pi*specdens_dust)*aer(dst_coarse)/(dst3_num*1.0e6_r8))**(1._r8/3._r8)
    endif
 
 end subroutine calculate_mass_mean_radius
 
 !====================================================================================================
 
-pure function get_aer_radius(specdens, aermc, aernum) result(radius)
-   
-   ! Compute radius for an aerosol species given mass and number concentrations
-
-   implicit none
-   real(r8), intent(in) :: specdens    ! density [kg/m^3]
-   real(r8), intent(in) :: aermc       ! aerosol mass concentration [kg/m^3]
-   real(r8), intent(in) :: aernum      ! aerosol number concentration [kg/m^3]
-
-   real(r8) :: radius                  ! return value radius [m]
-
-   radius = (3._r8/(4*pi*specdens)*aermc/aernum)**(1._r8/3._r8)
-
-end function get_aer_radius
-
-!====================================================================================================
-
-subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
+subroutine calculate_coated_fraction(ncnst, aer, rhoair, &
                                      total_interstitial_aer_num, &
                                      total_cloudborne_aer_num, &
                                      hetraer, &
                                      total_aer_num, coated_aer_num, uncoated_aer_num, &
                                      dstcoat, na500, tot_na500)
-
+   
    !***************************************************
    ! calculate total, coated, uncoated number 
    ! concentration for BC and dust
    !***************************************************
 
-    use mam_support, only: min_max_bound
+   use mam_support, only: min_max_bound
+
 
    ! input
    integer,  intent(in) :: ncnst
-   real(r8), intent(in) :: aer(ncnst)                     ! interstitial aerosol concentrations [kg/m^3]
-   real(r8), intent(in) :: rhoair                         ! air density [kg/m3]
-   real(r8), intent(in) :: total_interstitial_aer_num(hetfrz_aer_nspec)  ! interstitial concentrations of BC and dust [#/cm^3]
-   real(r8), intent(in) :: total_cloudborne_aer_num(hetfrz_aer_nspec)    ! cloudborne concentrations of BC and dust [#/cm^3]
-   real(r8), intent(in) :: hetraer(hetfrz_aer_nspec)                     ! BC and Dust mass mean radius [m]
+   real(r8), intent(in) :: aer(ncnst)    ! interstitial aerosols, volume basis
+   real(r8), intent(in) :: rhoair        ! air density (kg/m3)
+   real(r8), intent(in) :: total_interstitial_aer_num(hetfrz_aer_nspec) ! #/cm^3
+   real(r8), intent(in) :: total_cloudborne_aer_num(hetfrz_aer_nspec) ! #/cm^3
+   real(r8), intent(in) :: hetraer(hetfrz_aer_nspec)                  ! BC and Dust mass mean radius [m]
 
    ! output
-   real(r8), intent(out) :: total_aer_num(hetfrz_aer_nspec)              ! total bc and dust number concentration(interstitial+cloudborne) [#/cm^3]
-   real(r8), intent(out) :: coated_aer_num(hetfrz_aer_nspec)             ! coated bc and dust number concentration(interstitial) [#/cm^3] 
-   real(r8), intent(out) :: uncoated_aer_num(hetfrz_aer_nspec)           ! uncoated bc and dust number concentration(interstitial) [#/cm^3]
-   real(r8), intent(out) :: dstcoat(hetfrz_aer_nspec)                    ! coated fraction
+   real(r8), intent(out) :: total_aer_num(hetfrz_aer_nspec)            ! total bc and dust number concentration(interstitial+cloudborne) [#/cm^3]
+   real(r8), intent(out) :: coated_aer_num(hetfrz_aer_nspec)           ! coated bc and dust number concentration(interstitial) [#/cm^3] 
+   real(r8), intent(out) :: uncoated_aer_num(hetfrz_aer_nspec)         ! uncoated bc and dust number concentration(interstitial) [#/cm^3]
+   real(r8), intent(out) :: dstcoat(hetfrz_aer_nspec)                  ! coated fraction
    real(r8), intent(out) :: na500                         ! interstitial aerosol number with D>500 nm [#/cm^3]
    real(r8), intent(out) :: tot_na500                     ! total aerosol number with D>500 nm [#/cm^3]
 
@@ -1109,8 +1117,8 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    real(r8) :: coat_ratio1, coat_ratio2
    real(r8) :: bc_num, dst1_num, dst3_num         ! BC and dust number concentration [#/cm^3]
 
-   real(r8), parameter :: bc_kg_to_num = 4.669152e+17_r8      ! #/kg from emission
-   real(r8), parameter :: dst1_0p5um_scale = 0.488_r8    ! scaled for D>0.5-1 um from 0.1-1 um
+   real(r8), parameter :: bc_num_to_mass = 4.669152e+17_r8      ! #/kg from emission
+   real(r8), parameter :: dst1_0p5um_scale = 0.488_r8           ! scaled for D>0.5-1 um from 0.1-1 um
    real(r8), parameter :: bc_0p5um_scale = 0.0256_r8
 
    real(r8) :: r_bc                         ! model radii of BC modes [m]   
@@ -1126,11 +1134,11 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    dstcoat                   = 0._r8
    na500                     = 0._r8
    tot_na500                 = 0._r8
- 
 
-   bc_num   = total_interstitial_aer_num(1) 
-   dst1_num = total_interstitial_aer_num(2) 
-   dst3_num = total_interstitial_aer_num(3)  
+
+   bc_num   = total_interstitial_aer_num(1)
+   dst1_num = total_interstitial_aer_num(2)
+   dst3_num = total_interstitial_aer_num(3)
  
    r_bc      = hetraer(1)
    r_dust_a1 = hetraer(2)
@@ -1158,7 +1166,7 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    ! The soa_equivso4_factor accounts for the lower hygroscopicity of soa.
    !
    ! Define xferfrac_pcage = min(1.0, ratio1/ratio2)
-   !   But ratio1/ratio2 == tmp1/tmp2, and coding below avoids possible overflow 
+   !   But ratio1/ratio2 == tmp1/tmp2, and coding below avoids possible overflow
 
    ! bc
    fac_volsfc_bc      = exp(2.5_r8*alnsg_mode_pcarbon**2)
@@ -1186,7 +1194,8 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    coat_ratio1 = vol_shell(3)*(r_dust_a3*2._r8)*fac_volsfc_dust_a3
    coat_ratio2 = max(6.0_r8*dr_so4_monolayers_dust*vol_core(3), 0.0_r8)
    dstcoat(3) = coat_ratio1/coat_ratio2
-      
+
+   
    dstcoat(1) = min_max_bound(0.001_r8, 1.0_r8, dstcoat(1))
    dstcoat(2) = min_max_bound(0.001_r8, 1.0_r8, dstcoat(2))
    dstcoat(3) = min_max_bound(0.001_r8, 1.0_r8, dstcoat(3))
@@ -1196,13 +1205,13 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
       total_aer_num(ispec)    = total_interstitial_aer_num(ispec) + total_cloudborne_aer_num(ispec)
       coated_aer_num(ispec)   = total_interstitial_aer_num(ispec)*dstcoat(ispec)
       uncoated_aer_num(ispec) = total_interstitial_aer_num(ispec)*(1._r8-dstcoat(ispec))
-   enddo
+   enddo 
 
-   coated_aer_num(1)   = aer(bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*dstcoat(1)+ &
-                         aer(bc_accum)*bc_kg_to_num*num_m3_to_cm3
-
-   uncoated_aer_num(1) = aer(bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*(1._r8-dstcoat(1))
+   coated_aer_num(1)   = aer(bc_pcarbon)*bc_num_to_mass*num_m3_to_cm3*dstcoat(1)+ &
+                         aer(bc_accum)*bc_num_to_mass*num_m3_to_cm3
    
+   uncoated_aer_num(1) = aer(bc_pcarbon)*bc_num_to_mass*num_m3_to_cm3*(1._r8-dstcoat(1))
+
 
    tot_na500 = total_aer_num(1)*bc_0p5um_scale + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
                total_aer_num(2)*dst1_0p5um_scale + &
@@ -1211,7 +1220,8 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    na500 = total_interstitial_aer_num(1)*bc_0p5um_scale + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
            total_interstitial_aer_num(2)*dst1_0p5um_scale + &
            total_interstitial_aer_num(3)
-                
+
+  
 end subroutine calculate_coated_fraction
 
 !====================================================================================================
@@ -1236,46 +1246,52 @@ subroutine calculate_water_activity(ncnst, aer, &
    ! local variables
    real(r8) :: bc_num, dst1_num, dst3_num
    real(r8), parameter :: mass_kg_to_mug = 1.0e9_r8          ! mass unit conversion, kg to mug
-   real(r8) :: aermc_tmp
 
    bc_num   = total_interstitial_aer_num(1)
    dst1_num = total_interstitial_aer_num(2)
-   dst3_num = total_interstitial_aer_num(3)                                                                                                                        
-                                                                                                                                   
-   awcam  = 0.0_r8
-   awfacm = 0.0_r8
+   dst3_num = total_interstitial_aer_num(3)
 
-   aermc_tmp = aer(so4_accum) + aer(soa_accum) + aer(pom_accum) + aer(bc_accum) + aer(mom_accum)
-   
+   awcam  = 0._r8
+   awfacm = 0._r8
+
    ! accumulation mode for dust_a1 
    if (aer(num_accum) > 0._r8) then
-      awcam(2) = (dst1_num*num_cm3_to_m3)/aer(num_accum)*aermc_tmp*mass_kg_to_mug
+      awcam(2) = (dst1_num*1.0e6_r8)/aer(num_accum)* &
+            ( aer(so4_accum) + aer(soa_accum) + &
+              aer(pom_accum) + aer(bc_accum) + aer(mom_accum) )*1.0e9_r8 ! [mug m-3]
    endif
 
    if (awcam(2) > 0._r8) then
-      awfacm(2) = ( aer(bc_accum) + aer(soa_accum) + aer(pom_accum) + aer(mom_accum) )/aermc_tmp
+      awfacm(2) = ( aer(bc_accum) + aer(soa_accum) + aer(pom_accum) + aer(mom_accum) )/ &
+            ( aer(soa_accum) + aer(pom_accum) + aer(so4_accum) + aer(bc_accum) + aer(mom_accum) )
+   else
+      awfacm(2) = 0._r8
    endif
 
 
    ! accumulation mode for bc (if MAM4, primary carbon mode is insoluble)
    if (aer(num_accum) > 0._r8) then
-      awcam(1) = (bc_num*num_cm3_to_m3)/aer(num_accum)*aermc_tmp*mass_kg_to_mug ! [mug m-3]
+         awcam(1) = (bc_num*1.0e6_r8)/aer(num_accum)* &
+            ( aer(so4_accum) + aer(soa_accum) + aer(pom_accum) + aer(bc_accum) + &
+              aer(mom_accum) )*1.0e9_r8 ! [mug m-3]
    endif
-
    awfacm(1) = awfacm(2)
-
-   
-   aermc_tmp = aer(so4_coarse) + aer(mom_coarse) + aer(bc_coarse) + aer(pom_coarse) + aer(soa_coarse)
 
    ! coarse mode for dust_a3
    if (aer(num_coarse) > 0._r8) then
-      awcam(3) = (dst3_num*num_cm3_to_m3)/aer(num_coarse)*aermc_tmp*mass_kg_to_mug
+      awcam(3) = (dst3_num*1.0e6_r8)/aer(num_coarse)* ( aer(so4_coarse) + &
+                     aer(mom_coarse) + aer(bc_coarse) + aer(pom_coarse) + aer(soa_coarse) ) *1.0e9_r8
    endif
 
    if (awcam(3) > 0._r8) then
-      awfacm(3) = ( aer(bc_coarse) + aer(soa_coarse) + aer(pom_coarse) + aer(mom_coarse) )/aermc_tmp
+      awfacm(3) = ( aer(bc_coarse) + aer(soa_coarse) + &
+                       aer(pom_coarse) + aer(mom_coarse) )/ &
+                     ( aer(soa_coarse) + aer(pom_coarse) + &
+                       aer(so4_coarse) + aer(bc_coarse) + aer(mom_coarse) )
+   else
+      awfacm(3) = 0._r8
    endif
-                                                                                                
+
 end subroutine calculate_water_activity
 
 end module hetfrz_classnuc_cam

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -609,7 +609,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    associate( &
       lchnk => state%lchnk,             &
       ncol  => state%ncol,              &
-      t     => state%t,                 &
+      temperature     => state%t,                 &
       qc    => state%q(:pcols,:pver,cldliq_idx), &
       nc    => state%q(:pcols,:pver,numliq_idx), &
       pmid  => state%pmid               )
@@ -624,7 +624,7 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    do kk = top_lev, pver
       do icol = 1, ncol
-         rho(icol,kk) = pmid(icol,kk)/(rair*t(icol,kk))
+         rho(icol,kk) = pmid(icol,kk)/(rair*temperature(icol,kk))
       enddo
    enddo
 
@@ -765,14 +765,14 @@ subroutine hetfrz_classnuc_cam_calc( &
    do kk = top_lev, pver
       do icol = 1, ncol
 
-         if (t(icol,kk) > 235.15_r8 .and. t(icol,kk) < 269.15_r8) then
+         if (temperature(icol,kk) > 235.15_r8 .and. temperature(icol,kk) < 269.15_r8) then
             qcic = min(qc(icol,kk)/lcldm(icol,kk), 5.e-3_r8)
             ncic = max(nc(icol,kk)/lcldm(icol,kk), 0._r8)
 
             con1 = 1._r8/(1.333_r8*pi)**0.333_r8
             r3lx = con1*(rho(icol,kk)*qcic/(rhoh2o*max(ncic*rho(icol,kk), 1.0e6_r8)))**0.333_r8 ! in m
             r3lx = max(4.e-6_r8, r3lx)
-            supersatice = svp_water(t(icol,kk))/svp_ice(t(icol,kk))
+            supersatice = svp_water(temperature(icol,kk))/svp_ice(temperature(icol,kk))
 
             fn(1) = factnum(icol,kk,mode_accum_idx)  ! bc accumulation mode
             fn(2) = factnum(icol,kk,mode_accum_idx)  ! dust_a1 accumulation mode
@@ -780,7 +780,7 @@ subroutine hetfrz_classnuc_cam_calc( &
             
 
             call hetfrz_classnuc_calc( &
-               deltatin,  t(icol,kk),  pmid(icol,kk),  supersatice,   &
+               deltatin,  temperature(icol,kk),  pmid(icol,kk),  supersatice,   &
                fn,  r3lx,  ncic*rho(icol,kk)*1.0e-6_r8,  frzbcimm(icol,kk),  frzduimm(icol,kk),   &
                frzbccnt(icol,kk),  frzducnt(icol,kk),  frzbcdep(icol,kk),  frzdudep(icol,kk),  hetraer(icol,kk,:), &
                awcam(icol,kk,:), awfacm(icol,kk,:), dstcoat(icol,kk,:), total_aer_num(icol,kk,:),  &
@@ -1060,7 +1060,7 @@ pure function get_aer_radius(specdens, aermc, aernum) result(radius)
    implicit none
    real(r8), intent(in) :: specdens    ! density [kg/m^3]
    real(r8), intent(in) :: aermc       ! aerosol mass concentration [kg/m^3]
-   real(r8), intent(in) :: aernum      ! aerosol number concentration [kg/m^3]
+   real(r8), intent(in) :: aernum      ! aerosol number concentration [#/m^3]
 
    real(r8) :: radius                  ! return value radius [m]
 

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -621,14 +621,14 @@ subroutine hetfrz_classnuc_cam_calc( &
    do kk = top_lev, pver
       do icol = 1, ncol
          rho(icol,kk) = pmid(icol,kk)/(rair*t(icol,kk))
-      end do
-   end do
+      enddo
+   enddo
 
    do kk = top_lev, pver
       do icol = 1, ncol
          lcldm(icol,kk) = max(ast(icol,kk), mincld)
-      end do
-   end do
+      enddo
+   enddo
 
    ! Convert interstitial and cloud borne aerosols from a mass to a volume basis before
    ! being used in get_aer_num
@@ -640,9 +640,9 @@ subroutine hetfrz_classnuc_cam_calc( &
          call rad_cnst_get_mode_num(0, mode_idx(ispec), 'a', state, pbuf, ptr2d)
       else
          call rad_cnst_get_aer_mmr(0, mode_idx(ispec), spec_idx(ispec), 'a', state, pbuf, ptr2d)
-      end if
+      endif
       aer(:ncol,:,ispec,lchnk_zb) = ptr2d(:ncol,:) * rho(:ncol,:)
-   end do
+   enddo
 
    ! Init top levels of outputs of get_aer_num
    total_aer_num              = 0._r8
@@ -702,8 +702,8 @@ subroutine hetfrz_classnuc_cam_calc( &
          fn_cloudborne_aer_num(icol,kk,1) = total_aer_num(icol,kk,1)*factnum(icol,kk,mode_accum_idx)  ! bc
          fn_cloudborne_aer_num(icol,kk,2) = total_aer_num(icol,kk,2)*factnum(icol,kk,mode_accum_idx)  ! dst_a1
          fn_cloudborne_aer_num(icol,kk,3) = total_aer_num(icol,kk,3)*factnum(icol,kk,mode_coarse_idx) ! dst_a3
-      end do
-   end do
+      enddo
+   enddo
 
    call outfld('bc_num',        total_aer_num(:,:,1),    pcols, lchnk)
    call outfld('dst1_num',      total_aer_num(:,:,2),    pcols, lchnk)
@@ -796,7 +796,7 @@ subroutine hetfrz_classnuc_cam_calc( &
             frzimm(icol,kk) = 0._r8
             frzcnt(icol,kk) = 0._r8
             frzdep(icol,kk) = 0._r8
-         end if
+         endif
 
          nnuccc_bc(icol,kk) = frzbcimm(icol,kk)*1.0e6_r8*ast(icol,kk)
          nnucct_bc(icol,kk) = frzbccnt(icol,kk)*1.0e6_r8*ast(icol,kk)
@@ -817,8 +817,8 @@ subroutine hetfrz_classnuc_cam_calc( &
          numice10s(icol,kk) = (frzimm(icol,kk)+frzcnt(icol,kk)+frzdep(icol,kk))*1.0e6_r8*deltatin*(10._r8/deltatin)
          numice10s_imm_dst(icol,kk) = frzduimm(icol,kk)*1.0e6_r8*deltatin*(10._r8/deltatin)
          numice10s_imm_bc(icol,kk) = frzbcimm(icol,kk)*1.0e6_r8*deltatin*(10._r8/deltatin)
-      end do
-   end do
+      enddo
+   enddo
 
    call outfld('FREQIMM', freqimm, pcols, lchnk)
    call outfld('FREQCNT', freqcnt, pcols, lchnk)
@@ -930,7 +930,7 @@ subroutine calculate_interstitial_aer_num(ii, kk, ncnst, aer, &
 
    if (dmc > 0._r8 ) then
       total_interstitial_aer_num(3) = dmc/aermc_coarse_total * aer(ii,kk,num_coarse) * num_m3_to_cm3 ! #/cm^3
-   end if
+   endif
 
 end subroutine calculate_interstitial_aer_num                                                                                                                        
 
@@ -972,11 +972,11 @@ subroutine calculate_cloudborne_aer_num(ii, kk, ncnst, aer_cb, &
   
    if (as_bc > 0._r8) then
       total_cloudborne_aer_num(1) = as_bc/aermc_accum_total * aer_cb(ii,kk,num_accum) * num_m3_to_cm3 ! #/cm^3
-   end if
+   endif
 
    if (as_du > 0._r8) then
       total_cloudborne_aer_num(2) = as_du/aermc_accum_total * aer_cb(ii,kk,num_accum) * num_m3_to_cm3 ! #/cm^3
-   end if
+   endif
 
 
    dmc_imm = aer_cb(ii,kk,dst_coarse)
@@ -986,7 +986,7 @@ subroutine calculate_cloudborne_aer_num(ii, kk, ncnst, aer_cb, &
 
    if (dmc_imm > 0._r8) then
       total_cloudborne_aer_num(3) = dmc_imm/aermc_coarse_total * aer_cb(ii,kk,num_coarse) * num_m3_to_cm3 ! #/cm^3
-   end if
+   endif
 
 end subroutine calculate_cloudborne_aer_num                                                                                                                                    
 
@@ -1009,6 +1009,7 @@ subroutine calculate_mass_mean_radius(ii, kk, ncnst, aer, &
 
    ! local variables
    real(r8) :: bc_num, dst1_num, dst3_num                ! number concentration [#/cm^3]
+   real(r8), parameter :: num_cm3_to_m3  = 1.0e6_r8          ! volume unit conversion, #/cm^3 to #/m^3
    real(r8), parameter :: aermc_min_threshold  = 1.0e-30_r8
    real(r8), parameter :: aernum_min_threshold = 1.0e-3_r8
    real(r8), parameter :: r_bc_prescribed = 0.067e-6_r8
@@ -1026,20 +1027,20 @@ subroutine calculate_mass_mean_radius(ii, kk, ncnst, aer, &
    ! BC
    if ((aer(ii,kk,bc_accum)+aer(ii,kk,bc_pcarbon))*1.0e-3_r8 > aermc_min_threshold .and. bc_num > aernum_min_threshold) then
       hetraer(1) = (3._r8/(4*pi*specdens_bc)*(aer(ii,kk,bc_accum)+aer(ii,kk,bc_pcarbon))/ &
-                   (bc_num*1.0e6_r8))**(1._r8/3._r8)
-   end if
+                   (bc_num*num_cm3_to_m3))**(1._r8/3._r8)
+   endif
 
    ! fine dust a1
    if (aer(ii,kk,dst_accum)*1.0e-3_r8 > aermc_min_threshold .and. dst1_num > aernum_min_threshold) then
       hetraer(2) = (3._r8/(4*pi*specdens_dust)*aer(ii,kk,dst_accum)/&
-                   (dst1_num*1.0e6_r8))**(1._r8/3._r8)
-   end if
+                   (dst1_num*num_cm3_to_m3))**(1._r8/3._r8)
+   endif
 
    ! coarse dust a3
    if (aer(ii,kk,dst_coarse)*1.0e-3_r8 > aermc_min_threshold .and. dst3_num > aernum_min_threshold) then
       hetraer(3) = (3._r8/(4*pi*specdens_dust)*aer(ii,kk,dst_coarse)/&
-                   (dst3_num*1.0e6_r8))**(1._r8/3._r8)
-   end if
+                   (dst3_num*num_cm3_to_m3))**(1._r8/3._r8)
+   endif
 
 end subroutine calculate_mass_mean_radius
 
@@ -1180,7 +1181,7 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
       total_aer_num(ispec)    = total_interstitial_aer_num(ispec) + total_cloudborne_aer_num(ispec)
       coated_aer_num(ispec)   = total_interstitial_aer_num(ispec)*dstcoat(ispec)
       uncoated_aer_num(ispec) = total_interstitial_aer_num(ispec)*(1._r8-dstcoat(ispec))
-   end do
+   enddo
 
    coated_aer_num(1)   = aer(ii,kk,bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*dstcoat(1)+ &
                          aer(ii,kk,bc_accum)*bc_kg_to_num*num_m3_to_cm3
@@ -1234,12 +1235,12 @@ subroutine calculate_water_activity(ii, kk, ncnst, aer, &
       awcam(2) = (dst1_num*num_cm3_to_m3)/aer(ii,kk,num_accum)* &
                  (aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
                   aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum))*mass_kg_to_mug ! [mug m-3]
-   end if
+   endif
 
    if (awcam(2) > 0._r8) then
       awfacm(2) = ( aer(ii,kk,bc_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,mom_accum) )/ &
                   ( aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,so4_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum) )
-   end if
+   endif
 
 
    ! accumulation mode for bc (if MAM4, primary carbon mode is insoluble)
@@ -1247,7 +1248,7 @@ subroutine calculate_water_activity(ii, kk, ncnst, aer, &
       awcam(1) = (bc_num*num_cm3_to_m3)/aer(ii,kk,num_accum)* &
                  (aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
                   aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum))  * mass_kg_to_mug ! [mug m-3]
-   end if
+   endif
 
    awfacm(1) = awfacm(2)
 
@@ -1257,14 +1258,14 @@ subroutine calculate_water_activity(ii, kk, ncnst, aer, &
       awcam(3) = (dst3_num*num_cm3_to_m3)/aer(ii,kk,num_coarse)* &
                  (aer(ii,kk,so4_coarse) + aer(ii,kk,mom_coarse) + &
                   aer(ii,kk,bc_coarse) + aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse)) * mass_kg_to_mug
-   end if
+   endif
 
    if (awcam(3) > 0._r8) then
       awfacm(3) = ( aer(ii,kk,bc_coarse) + aer(ii,kk,soa_coarse) + &
                     aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) ) / &
                   ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &
                     aer(ii,kk,so4_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,mom_coarse) )
-   end if
+   endif
                                                                                                 
 end subroutine calculate_water_activity
 

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -1020,6 +1020,7 @@ subroutine calculate_mass_mean_radius(ncnst, aer, &
    dst1_num = total_interstitial_aer_num(2)
    dst3_num = total_interstitial_aer_num(3)
 
+   ! Initialize hetraer with prescribed radius
    hetraer(1) = r_bc_prescribed
    hetraer(2) = r_dust_a1_prescribed
    hetraer(3) = r_dust_a3_prescribed
@@ -1109,7 +1110,8 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    real(r8) :: bc_num, dst1_num, dst3_num         ! BC and dust number concentration [#/cm^3]
 
    real(r8), parameter :: bc_kg_to_num = 4.669152e+17_r8      ! #/kg from emission
-   real(r8), parameter :: dst1_scale = 0.488_r8    ! scaled for D>0.5-1 um from 0.1-1 um
+   real(r8), parameter :: dst1_0p5um_scale = 0.488_r8    ! scaled for D>0.5-1 um from 0.1-1 um
+   real(r8), parameter :: bc_0p5um_scale = 0.0256_r8
 
    real(r8) :: r_bc                         ! model radii of BC modes [m]   
    real(r8) :: r_dust_a1, r_dust_a3         ! model radii of dust modes [m]   
@@ -1202,12 +1204,12 @@ subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
    uncoated_aer_num(1) = aer(bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*(1._r8-dstcoat(1))
    
 
-   tot_na500 = total_aer_num(1)*0.0256_r8 + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
-               total_aer_num(2)*dst1_scale + &
+   tot_na500 = total_aer_num(1)*bc_0p5um_scale + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
+               total_aer_num(2)*dst1_0p5um_scale + &
                total_aer_num(3)
 
-   na500 = total_interstitial_aer_num(1)*0.0256_r8 + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
-           total_interstitial_aer_num(2)*dst1_scale + &
+   na500 = total_interstitial_aer_num(1)*bc_0p5um_scale + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
+           total_interstitial_aer_num(2)*dst1_0p5um_scale + &
            total_interstitial_aer_num(3)
                 
 end subroutine calculate_coated_fraction

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -683,15 +683,15 @@ subroutine hetfrz_classnuc_cam_calc( &
    ! output aerosols as reference information for heterogeneous freezing
    do kk = top_lev, pver
       do icol = 1, ncol
-         call calculate_interstitial_aer_num(ncnst, aer(icol,kk,:,lchnk_zb), & ! in 
+         call calculate_interstitial_aer_num(ncnst, aer(icol,kk,:,lchnk_zb), &      ! in 
                                              total_interstitial_aer_num(icol,kk,:)) ! out
 
          call calculate_cloudborne_aer_num(ncnst, aer_cb(icol,kk,:,lchnk_zb), & ! in
                                            total_cloudborne_aer_num(icol,kk,:)) ! out 
 
-         call calculate_mass_mean_radius(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in
+         call calculate_mass_mean_radius(ncnst, aer(icol,kk,:,lchnk_zb), &         ! in
                                          total_interstitial_aer_num(icol,kk,:), &  ! in
-                                         hetraer(icol,kk,:)) ! out
+                                         hetraer(icol,kk,:))                       ! out
 
 
          call calculate_coated_fraction(ncnst, aer(icol,kk,:,lchnk_zb), rho(icol,kk), &                                      ! in
@@ -700,9 +700,9 @@ subroutine hetfrz_classnuc_cam_calc( &
                                         total_aer_num(icol,kk,:), coated_aer_num(icol,kk,:), uncoated_aer_num(icol,kk,:), &  ! out
                                         dstcoat(icol,kk,:), na500(icol,kk), tot_na500(icol,kk))                              ! out
 
-         call calculate_water_activity(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in        
-                                       total_interstitial_aer_num(icol,kk,:), & ! in        
-                                       awcam(icol,kk,:), awfacm(icol,kk,:)) ! out
+         call calculate_vars_for_water_activity(ncnst, aer(icol,kk,:,lchnk_zb), &        ! in        
+                                                total_interstitial_aer_num(icol,kk,:), & ! in        
+                                                awcam(icol,kk,:), awfacm(icol,kk,:))     ! out
 
          fn_cloudborne_aer_num(icol,kk,1) = total_aer_num(icol,kk,1)*factnum(icol,kk,mode_accum_idx)  ! bc
          fn_cloudborne_aer_num(icol,kk,2) = total_aer_num(icol,kk,2)*factnum(icol,kk,mode_accum_idx)  ! dst_a1
@@ -1228,7 +1228,7 @@ end subroutine calculate_coated_fraction
 
 !====================================================================================================
 
-subroutine calculate_water_activity(ncnst, aer, &
+subroutine calculate_vars_for_water_activity(ncnst, aer, &
                                     total_interstitial_aer_num, &
                                     awcam, awfacm)
 
@@ -1290,6 +1290,6 @@ subroutine calculate_water_activity(ncnst, aer, &
                        aer(so4_coarse) + aer(bc_coarse) + aer(mom_coarse) )
    endif
 
-end subroutine calculate_water_activity
+end subroutine calculate_vars_for_water_activity
 
 end module hetfrz_classnuc_cam

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -677,25 +677,25 @@ subroutine hetfrz_classnuc_cam_calc( &
 
 
    ! output aerosols as reference information for heterogeneous freezing
-   do icol = 1, ncol
-      do kk = top_lev, pver
-         call calculate_interstitial_aer_num(icol, kk, ncnst, aer(:,:,:,lchnk_zb), & ! in 
+   do kk = top_lev, pver
+      do icol = 1, ncol
+         call calculate_interstitial_aer_num(ncnst, aer(icol,kk,:,lchnk_zb), & ! in 
                                              total_interstitial_aer_num(icol,kk,:))  ! out
 
-         call calculate_cloudborne_aer_num(icol, kk, ncnst, aer_cb(:,:,:,lchnk_zb), &  ! in
+         call calculate_cloudborne_aer_num(ncnst, aer_cb(icol,kk,:,lchnk_zb), &  ! in
                                            total_cloudborne_aer_num(icol,kk,:))        ! out                                                                                        
 
-         call calculate_mass_mean_radius(icol, kk, ncnst, aer(:,:,:,lchnk_zb), &   ! in
+         call calculate_mass_mean_radius(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in
                                          total_interstitial_aer_num(icol,kk,:), &  ! in
                                          hetraer(icol,kk,:))                       ! out
 
-         call calculate_coated_fraction(icol, kk, ncnst, aer(:,:,:,lchnk_zb), rho(icol,kk), &                                ! in
+         call calculate_coated_fraction(ncnst, aer(icol,kk,:,lchnk_zb), rho(icol,kk), &                                ! in
                                         total_interstitial_aer_num(icol,kk,:), total_cloudborne_aer_num(icol,kk,:), &        ! in
                                         hetraer(icol,kk,:), &                                                                ! in 
                                         total_aer_num(icol,kk,:), coated_aer_num(icol,kk,:), uncoated_aer_num(icol,kk,:), &  ! out      
                                         dstcoat(icol,kk,:), na500(icol,kk), tot_na500(icol,kk))                              ! out     
 
-         call calculate_water_activity(icol, kk, ncnst, aer(:,:,:,lchnk_zb), &   ! in        
+         call calculate_water_activity(ncnst, aer(icol,kk,:,lchnk_zb), &   ! in        
                                        total_interstitial_aer_num(icol,kk,:), &  ! in        
                                        awcam(icol,kk,:), awfacm(icol,kk,:))      ! out
 
@@ -757,8 +757,8 @@ subroutine hetfrz_classnuc_cam_calc( &
    numice10s_imm_dst(:ncol,:) = 0._r8
    numice10s_imm_bc(:ncol,:)  = 0._r8
 
-   do icol = 1, ncol
-      do kk = top_lev, pver
+   do kk = top_lev, pver
+      do icol = 1, ncol
 
          if (t(icol,kk) > 235.15_r8 .and. t(icol,kk) < 269.15_r8) then
             qcic = min(qc(icol,kk)/lcldm(icol,kk), 5.e-3_r8)
@@ -890,7 +890,7 @@ end subroutine hetfrz_classnuc_cam_save_cbaero
 
 !====================================================================================================
 
-subroutine calculate_interstitial_aer_num(ii, kk, ncnst, aer, &
+subroutine calculate_interstitial_aer_num(ncnst, aer, &
                                           total_interstitial_aer_num)
 
    !***************************************************
@@ -899,8 +899,8 @@ subroutine calculate_interstitial_aer_num(ii, kk, ncnst, aer, &
    !***************************************************
 
    ! input
-   integer,  intent(in) :: ii, kk, ncnst
-   real(r8), intent(in) :: aer(pcols,pver,ncnst)  ! interstitial aerosol concentrations [kg/m^3]
+   integer,  intent(in) :: ncnst
+   real(r8), intent(in) :: aer(ncnst)  ! interstitial aerosol concentrations [kg/m^3]
 
    ! output
    real(r8), intent(out) :: total_interstitial_aer_num(3) ! interstitial concentrations of BC and dust [#/cm^3]
@@ -917,26 +917,26 @@ subroutine calculate_interstitial_aer_num(ii, kk, ncnst, aer, &
 
    total_interstitial_aer_num = 0.0_r8
 
-   total_interstitial_aer_num(1) = aer(ii,kk,bc_accum) * bc_kg_to_num * num_m3_to_cm3 ! #/cm^3
-   total_interstitial_aer_num(1) = total_interstitial_aer_num(1) + aer(ii,kk,bc_pcarbon) * bc_kg_to_num * num_m3_to_cm3
+   total_interstitial_aer_num(1) = aer(bc_accum) * bc_kg_to_num * num_m3_to_cm3 ! #/cm^3
+   total_interstitial_aer_num(1) = total_interstitial_aer_num(1) + aer(bc_pcarbon) * bc_kg_to_num * num_m3_to_cm3
 
-   total_interstitial_aer_num(2) = aer(ii,kk,dst_accum) * dst1_kg_to_num * num_m3_to_cm3 ! #/cm^3, dust # in accumulation mode
+   total_interstitial_aer_num(2) = aer(dst_accum) * dst1_kg_to_num * num_m3_to_cm3 ! #/cm^3, dust # in accumulation mode
 
 
-   aermc_coarse_total = aer(ii,kk,dst_coarse) + aer(ii,kk,ncl_coarse) + aer(ii,kk,mom_coarse) + &
-                        aer(ii,kk,bc_coarse)  + aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse)
+   aermc_coarse_total = aer(dst_coarse) + aer(ncl_coarse) + aer(mom_coarse) + &
+                        aer(bc_coarse)  + aer(pom_coarse) + aer(soa_coarse)
 
-   dmc = aer(ii,kk,dst_coarse)
+   dmc = aer(dst_coarse)
 
    if (dmc > 0._r8 ) then
-      total_interstitial_aer_num(3) = dmc/aermc_coarse_total * aer(ii,kk,num_coarse) * num_m3_to_cm3 ! #/cm^3
+      total_interstitial_aer_num(3) = dmc/aermc_coarse_total * aer(num_coarse) * num_m3_to_cm3 ! #/cm^3
    endif
 
 end subroutine calculate_interstitial_aer_num                                                                                                                        
 
 !====================================================================================================                                                                               
 
-subroutine calculate_cloudborne_aer_num(ii, kk, ncnst, aer_cb, &
+subroutine calculate_cloudborne_aer_num(ncnst, aer_cb, &
                                         total_cloudborne_aer_num)
 
    !***************************************************
@@ -945,8 +945,8 @@ subroutine calculate_cloudborne_aer_num(ii, kk, ncnst, aer_cb, &
    !***************************************************
 
    ! input
-   integer,  intent(in) :: ii, kk, ncnst
-   real(r8), intent(in) :: aer_cb(pcols,pver,ncnst) ! cloud borne aerosol concentrations [kg/m^3]
+   integer,  intent(in) :: ncnst
+   real(r8), intent(in) :: aer_cb(ncnst) ! cloud borne aerosol concentrations [kg/m^3]
 
    ! output
    real(r8), intent(out) :: total_cloudborne_aer_num(3) ! cloudborne concentrations of BC and dust [#/cm^3]
@@ -963,35 +963,35 @@ subroutine calculate_cloudborne_aer_num(ii, kk, ncnst, aer_cb, &
 
    total_cloudborne_aer_num = 0.0_r8
 
-   as_du = aer_cb(ii,kk,dst_accum)
-   as_bc = aer_cb(ii,kk,bc_accum)
+   as_du = aer_cb(dst_accum)
+   as_bc = aer_cb(bc_accum)
    
-   aermc_accum_total = aer_cb(ii,kk,so4_accum) + aer_cb(ii,kk,bc_accum)  + aer_cb(ii,kk,pom_accum) + &
-                       aer_cb(ii,kk,soa_accum) + aer_cb(ii,kk,ncl_accum) + aer_cb(ii,kk,dst_accum) + &
-                       aer_cb(ii,kk,mom_accum)
+   aermc_accum_total = aer_cb(so4_accum) + aer_cb(bc_accum)  + aer_cb(pom_accum) + &
+                       aer_cb(soa_accum) + aer_cb(ncl_accum) + aer_cb(dst_accum) + &
+                       aer_cb(mom_accum)
   
    if (as_bc > 0._r8) then
-      total_cloudborne_aer_num(1) = as_bc/aermc_accum_total * aer_cb(ii,kk,num_accum) * num_m3_to_cm3 ! #/cm^3
+      total_cloudborne_aer_num(1) = as_bc/aermc_accum_total * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
    endif
 
    if (as_du > 0._r8) then
-      total_cloudborne_aer_num(2) = as_du/aermc_accum_total * aer_cb(ii,kk,num_accum) * num_m3_to_cm3 ! #/cm^3
+      total_cloudborne_aer_num(2) = as_du/aermc_accum_total * aer_cb(num_accum) * num_m3_to_cm3 ! #/cm^3
    endif
 
 
-   dmc_imm = aer_cb(ii,kk,dst_coarse)
+   dmc_imm = aer_cb(dst_coarse)
 
-   aermc_coarse_total = aer_cb(ii,kk,ncl_coarse) + aer_cb(ii,kk,dst_coarse) + aer_cb(ii,kk,bc_coarse) + &
-                        aer_cb(ii,kk,pom_coarse) + aer_cb(ii,kk,soa_coarse) + aer_cb(ii,kk,mom_coarse)
+   aermc_coarse_total = aer_cb(ncl_coarse) + aer_cb(dst_coarse) + aer_cb(bc_coarse) + &
+                        aer_cb(pom_coarse) + aer_cb(soa_coarse) + aer_cb(mom_coarse)
 
    if (dmc_imm > 0._r8) then
-      total_cloudborne_aer_num(3) = dmc_imm/aermc_coarse_total * aer_cb(ii,kk,num_coarse) * num_m3_to_cm3 ! #/cm^3
+      total_cloudborne_aer_num(3) = dmc_imm/aermc_coarse_total * aer_cb(num_coarse) * num_m3_to_cm3 ! #/cm^3
    endif
 
 end subroutine calculate_cloudborne_aer_num                                                                                                                                    
 
 !====================================================================================================                                                                                                                                      
-subroutine calculate_mass_mean_radius(ii, kk, ncnst, aer, &
+subroutine calculate_mass_mean_radius(ncnst, aer, &
                                       total_interstitial_aer_num, &
                                       hetraer)
 
@@ -1000,8 +1000,8 @@ subroutine calculate_mass_mean_radius(ii, kk, ncnst, aer, &
    !***************************************************
 
    ! input
-   integer,  intent(in) :: ii, kk, ncnst
-   real(r8), intent(in) :: aer(pcols,pver,ncnst)         ! interstitial aerosol concentrations [kg/m^3]
+   integer,  intent(in) :: ncnst
+   real(r8), intent(in) :: aer(ncnst) ! interstitial aerosol concentrations [kg/m^3]
    real(r8), intent(in) :: total_interstitial_aer_num(3) ! interstitial concentrations of BC and dust [#/cm^3]
 
    ! output
@@ -1025,20 +1025,20 @@ subroutine calculate_mass_mean_radius(ii, kk, ncnst, aer, &
    hetraer(3) = r_dust_a3_prescribed
 
    ! BC
-   if ((aer(ii,kk,bc_accum)+aer(ii,kk,bc_pcarbon))*1.0e-3_r8 > aermc_min_threshold .and. bc_num > aernum_min_threshold) then
-      hetraer(1) = (3._r8/(4*pi*specdens_bc)*(aer(ii,kk,bc_accum)+aer(ii,kk,bc_pcarbon))/ &
+   if ((aer(bc_accum)+aer(bc_pcarbon))*1.0e-3_r8 > aermc_min_threshold .and. bc_num > aernum_min_threshold) then
+      hetraer(1) = (3._r8/(4*pi*specdens_bc)*(aer(bc_accum)+aer(bc_pcarbon))/ &
                    (bc_num*num_cm3_to_m3))**(1._r8/3._r8)
    endif
 
    ! fine dust a1
-   if (aer(ii,kk,dst_accum)*1.0e-3_r8 > aermc_min_threshold .and. dst1_num > aernum_min_threshold) then
-      hetraer(2) = (3._r8/(4*pi*specdens_dust)*aer(ii,kk,dst_accum)/&
+   if (aer(dst_accum)*1.0e-3_r8 > aermc_min_threshold .and. dst1_num > aernum_min_threshold) then
+      hetraer(2) = (3._r8/(4*pi*specdens_dust)*aer(dst_accum)/&
                    (dst1_num*num_cm3_to_m3))**(1._r8/3._r8)
    endif
 
    ! coarse dust a3
-   if (aer(ii,kk,dst_coarse)*1.0e-3_r8 > aermc_min_threshold .and. dst3_num > aernum_min_threshold) then
-      hetraer(3) = (3._r8/(4*pi*specdens_dust)*aer(ii,kk,dst_coarse)/&
+   if (aer(dst_coarse)*1.0e-3_r8 > aermc_min_threshold .and. dst3_num > aernum_min_threshold) then
+      hetraer(3) = (3._r8/(4*pi*specdens_dust)*aer(dst_coarse)/&
                    (dst3_num*num_cm3_to_m3))**(1._r8/3._r8)
    endif
 
@@ -1046,7 +1046,7 @@ end subroutine calculate_mass_mean_radius
 
 !====================================================================================================
 
-subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
+subroutine calculate_coated_fraction(ncnst, aer,  rhoair, &
                                      total_interstitial_aer_num, &
                                      total_cloudborne_aer_num, &
                                      hetraer, &
@@ -1061,8 +1061,8 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
     use mam_support, only: min_max_bound
 
    ! input
-   integer,  intent(in) :: ii, kk, ncnst
-   real(r8), intent(in) :: aer(pcols,pver,ncnst)          ! interstitial aerosol concentrations [kg/m^3]
+   integer,  intent(in) :: ncnst
+   real(r8), intent(in) :: aer(ncnst)                     ! interstitial aerosol concentrations [kg/m^3]
    real(r8), intent(in) :: rhoair                         ! air density [kg/m3]
    real(r8), intent(in) :: total_interstitial_aer_num(3)  ! interstitial concentrations of BC and dust [#/cm^3]
    real(r8), intent(in) :: total_cloudborne_aer_num(3)    ! cloudborne concentrations of BC and dust [#/cm^3]
@@ -1126,13 +1126,13 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
    fac_volsfc_dust_a1 = exp(2.5_r8*alnsg_mode_accum**2)
    fac_volsfc_dust_a3 = exp(2.5_r8*alnsg_mode_coarse**2)
 
-   vol_shell(2) = ( aer(ii,kk,so4_accum)/specdens_so4 + &
-                    aer(ii,kk,pom_accum)*pom_equivso4_factor/specdens_pom + &
-                    aer(ii,kk,mom_accum)*mom_equivso4_factor/specdens_mom + &
-                    aer(ii,kk,soa_accum)*soa_equivso4_factor/specdens_soa )/rhoair
+   vol_shell(2) = ( aer(so4_accum)/specdens_so4 + &
+                    aer(pom_accum)*pom_equivso4_factor/specdens_pom + &
+                    aer(mom_accum)*mom_equivso4_factor/specdens_mom + &
+                    aer(soa_accum)*soa_equivso4_factor/specdens_soa )/rhoair
 
 
-   vol_core(2) = aer(ii,kk,dst_accum)/(specdens_dust*rhoair)
+   vol_core(2) = aer(dst_accum)/(specdens_dust*rhoair)
 
    ! ratio1 = vol_shell/vol_core = actual hygroscopic-shell-volume/dust-core-volume
    ! ratio2 = 6.0_r8*dr_so4_monolayers_pcage/(dgncur_a*fac_volsfc_dust)
@@ -1148,10 +1148,10 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
    ! bc
    fac_volsfc_bc      = exp(2.5_r8*alnsg_mode_pcarbon**2)
 
-   vol_shell(1) = ( aer(ii,kk,pom_pcarbon)*pom_equivso4_factor/specdens_pom + &
-                    aer(ii,kk,mom_pcarbon)*mom_equivso4_factor/specdens_mom )/rhoair
+   vol_shell(1) = ( aer(pom_pcarbon)*pom_equivso4_factor/specdens_pom + &
+                    aer(mom_pcarbon)*mom_equivso4_factor/specdens_mom )/rhoair
 
-   vol_core(1)  = aer(ii,kk,bc_pcarbon)/(specdens_bc*rhoair)
+   vol_core(1)  = aer(bc_pcarbon)/(specdens_bc*rhoair)
    coat_ratio1 = vol_shell(1)*(r_bc*2._r8)*fac_volsfc_bc
    coat_ratio2 = max(6.0_r8*dr_so4_monolayers_dust*vol_core(1), 0.0_r8)
    dstcoat(1) = coat_ratio1/coat_ratio2
@@ -1162,12 +1162,12 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
    dstcoat(2) = coat_ratio1/coat_ratio2
 
    ! dust_a3
-   vol_shell(3) = aer(ii,kk,so4_coarse)/(specdens_so4*rhoair) + & 
-                  aer(ii,kk,pom_coarse)/(specdens_pom*rhoair) + & 
-                  aer(ii,kk,soa_coarse)/(specdens_soa*rhoair) + & 
-                  aer(ii,kk,mom_coarse)/(specdens_mom*rhoair)
+   vol_shell(3) = aer(so4_coarse)/(specdens_so4*rhoair) + & 
+                  aer(pom_coarse)/(specdens_pom*rhoair) + & 
+                  aer(soa_coarse)/(specdens_soa*rhoair) + & 
+                  aer(mom_coarse)/(specdens_mom*rhoair)
 
-   vol_core(3)  = aer(ii,kk,dst_coarse)/(specdens_dust*rhoair)
+   vol_core(3)  = aer(dst_coarse)/(specdens_dust*rhoair)
    coat_ratio1 = vol_shell(3)*(r_dust_a3*2._r8)*fac_volsfc_dust_a3
    coat_ratio2 = max(6.0_r8*dr_so4_monolayers_dust*vol_core(3), 0.0_r8)
    dstcoat(3) = coat_ratio1/coat_ratio2
@@ -1183,10 +1183,10 @@ subroutine calculate_coated_fraction(ii, kk, ncnst, aer,  rhoair, &
       uncoated_aer_num(ispec) = total_interstitial_aer_num(ispec)*(1._r8-dstcoat(ispec))
    enddo
 
-   coated_aer_num(1)   = aer(ii,kk,bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*dstcoat(1)+ &
-                         aer(ii,kk,bc_accum)*bc_kg_to_num*num_m3_to_cm3
+   coated_aer_num(1)   = aer(bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*dstcoat(1)+ &
+                         aer(bc_accum)*bc_kg_to_num*num_m3_to_cm3
 
-   uncoated_aer_num(1) = aer(ii,kk,bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*(1._r8-dstcoat(1))
+   uncoated_aer_num(1) = aer(bc_pcarbon)*bc_kg_to_num*num_m3_to_cm3*(1._r8-dstcoat(1))
    
 
    tot_na500 = total_aer_num(1)*0.0256_r8 + &   ! scaled for D>0.5 um using Clarke et al., 1997; 2004; 2007: rg=0.1um, sig=1.6
@@ -1201,7 +1201,7 @@ end subroutine calculate_coated_fraction
 
 !====================================================================================================
 
-subroutine calculate_water_activity(ii, kk, ncnst, aer, &
+subroutine calculate_water_activity(ncnst, aer, &
                                     total_interstitial_aer_num, &
                                     awcam, awfacm)
 
@@ -1210,8 +1210,8 @@ subroutine calculate_water_activity(ii, kk, ncnst, aer, &
    !***************************************************
 
    ! input
-   integer,  intent(in) :: ii, kk, ncnst
-   real(r8), intent(in) :: aer(pcols,pver,ncnst)         ! interstitial aerosol concentrations [kg/m^3]
+   integer,  intent(in) :: ncnst
+   real(r8), intent(in) :: aer(ncnst)                    ! interstitial aerosol concentrations [kg/m^3]
    real(r8), intent(in) :: total_interstitial_aer_num(3) ! interstitial concentrations of BC and dust [#/cm^3]
 
    ! output
@@ -1231,40 +1231,40 @@ subroutine calculate_water_activity(ii, kk, ncnst, aer, &
    awfacm = 0.0_r8
    
    ! accumulation mode for dust_a1 
-   if (aer(ii,kk,num_accum) > 0._r8) then
-      awcam(2) = (dst1_num*num_cm3_to_m3)/aer(ii,kk,num_accum)* &
-                 (aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
-                  aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum))*mass_kg_to_mug ! [mug m-3]
+   if (aer(num_accum) > 0._r8) then
+      awcam(2) = (dst1_num*num_cm3_to_m3)/aer(num_accum)* &
+                 (aer(so4_accum) + aer(soa_accum) + &
+                  aer(pom_accum) + aer(bc_accum) + aer(mom_accum))*mass_kg_to_mug ! [mug m-3]
    endif
 
    if (awcam(2) > 0._r8) then
-      awfacm(2) = ( aer(ii,kk,bc_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,mom_accum) )/ &
-                  ( aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,so4_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum) )
+      awfacm(2) = ( aer(bc_accum) + aer(soa_accum) + aer(pom_accum) + aer(mom_accum) )/ &
+                  ( aer(soa_accum) + aer(pom_accum) + aer(so4_accum) + aer(bc_accum) + aer(mom_accum) )
    endif
 
 
    ! accumulation mode for bc (if MAM4, primary carbon mode is insoluble)
-   if (aer(ii,kk,num_accum) > 0._r8) then
-      awcam(1) = (bc_num*num_cm3_to_m3)/aer(ii,kk,num_accum)* &
-                 (aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
-                  aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum))  * mass_kg_to_mug ! [mug m-3]
+   if (aer(num_accum) > 0._r8) then
+      awcam(1) = (bc_num*num_cm3_to_m3)/aer(num_accum)* &
+                 (aer(so4_accum) + aer(soa_accum) + &
+                  aer(pom_accum) + aer(bc_accum) + aer(mom_accum))  * mass_kg_to_mug ! [mug m-3]
    endif
 
    awfacm(1) = awfacm(2)
 
 
    ! coarse mode for dust_a3
-   if (aer(ii,kk,num_coarse) > 0._r8) then
-      awcam(3) = (dst3_num*num_cm3_to_m3)/aer(ii,kk,num_coarse)* &
-                 (aer(ii,kk,so4_coarse) + aer(ii,kk,mom_coarse) + &
-                  aer(ii,kk,bc_coarse) + aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse)) * mass_kg_to_mug
+   if (aer(num_coarse) > 0._r8) then
+      awcam(3) = (dst3_num*num_cm3_to_m3)/aer(num_coarse)* &
+                 (aer(so4_coarse) + aer(mom_coarse) + &
+                  aer(bc_coarse) + aer(pom_coarse) + aer(soa_coarse)) * mass_kg_to_mug
    endif
 
    if (awcam(3) > 0._r8) then
-      awfacm(3) = ( aer(ii,kk,bc_coarse) + aer(ii,kk,soa_coarse) + &
-                    aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) ) / &
-                  ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &
-                    aer(ii,kk,so4_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,mom_coarse) )
+      awfacm(3) = ( aer(bc_coarse) + aer(soa_coarse) + &
+                    aer(pom_coarse) + aer(mom_coarse) ) / &
+                  ( aer(soa_coarse) + aer(pom_coarse) + &
+                    aer(so4_coarse) + aer(bc_coarse) + aer(mom_coarse) )
    endif
                                                                                                 
 end subroutine calculate_water_activity

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -1056,6 +1056,8 @@ end subroutine calculate_mass_mean_radius
 pure function get_aer_radius(specdens, aermc, aernum) result(radius)
 
    ! Compute radius for an aerosol species given mass and number concentrations
+   ! Note for C++ port: This function may already be present in the C++ utility
+   ! functions
 
    implicit none
    real(r8), intent(in) :: specdens    ! density [kg/m^3]


### PR DESCRIPTION
Break subroutine get_aer_num into 5 small subroutines

calculate_interstitial_aer_num
calculate_cloudborne_aer_num
calculate_mass_mean_radius
calculate_coated_fraction
calculate_water_activity

probably need to revist for aerosol arrays: aer and aer_cb (get from state%q array)
