### PR TITLE
Refactored dry deposition velocity calculations

### DIFF
--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -526,19 +526,34 @@ contains
     do kk=1,pver
        do ii=1,ncol
 
+          vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
+              mfp_atm(ii,kk) = air_mean_free_path( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi )
+
+          rho=pmid(ii,kk)/rair/tair(ii,kk)
+          vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
+
+       enddo
+    enddo
+
+
+    do kk=1,pver
+       do ii=1,ncol
+
+          lnsig = log(sig_part(ii,kk))
+          radius_moment(ii,kk) = min(radiaus_max,radius_part(ii,kk))*exp((float(moment)-1.5_r8)*lnsig*lnsig)
+          slp_crc(ii,kk) = slip_correction_factor( mfp_atm(ii,kk), radius_moment(ii,kk) ) 
+       enddo
+    enddo
+
+    do kk=1,pver
+       do ii=1,ncol
+
           lnsig = log(sig_part(ii,kk))
           radius_moment(ii,kk) = min(radiaus_max,radius_part(ii,kk))*exp((float(moment)-1.5_r8)*lnsig*lnsig)
           dispersion = exp(2._r8*lnsig*lnsig)
-
-          rho=pmid(ii,kk)/rair/tair(ii,kk)
-
-          vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
-              mfp_atm(ii,kk) = air_mean_free_path( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi )
-          vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
-              slp_crc(ii,kk) = slip_correction_factor( mfp_atm(ii,kk), radius_moment(ii,kk) ) 
-              vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment(ii,kk), density_part(ii,kk), &
-                                                         gravit, slp_crc(ii,kk), vsc_dyn_atm(ii,kk),&
-                                                         dispersion )
+          vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment(ii,kk), density_part(ii,kk), &
+                                                     gravit, slp_crc(ii,kk), vsc_dyn_atm(ii,kk),&
+                                                     dispersion )
        enddo
     enddo
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -536,12 +536,9 @@ contains
           ! Size-independent thermokinetic properties
 
           vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
-          mfp_atm(ii,kk) = air_mean_free_path( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi )
+              mfp_atm(ii,kk) = air_mean_free_path( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi )
           vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
-
-          slp_crc(ii,kk) = 1.0_r8 + mfp_atm(ii,kk) * &
-                           (1.257_r8+0.4_r8*exp(-1.1_r8*radius_moment(ii,kk)/(mfp_atm(ii,kk)))) / &
-                           radius_moment(ii,kk)   ![frc] Slip correction factor SeP97 p. 464
+              slp_crc(ii,kk) = slip_correction_factor( mfp_atm(ii,kk), radius_moment(ii,kk) ) 
 
           vlc_grv(ii,kk) = (4.0_r8/18.0_r8) * radius_moment(ii,kk)*radius_moment(ii,kk)*density_part(ii,kk)* &
                            gravit*slp_crc(ii,kk) / vsc_dyn_atm(ii,kk) ![m s-1] Stokes' settling velocity SeP97 p. 466
@@ -760,5 +757,19 @@ real(r8) function air_mean_free_path( dyn_visc, pres, temp, rair, pi )
   air_mean_free_path = 2.0_r8*dyn_visc/( pres*sqrt( 8.0_r8/(pi*rair*temp) ) )
 
 end function air_mean_free_path
+
+  !======================================================
+  ! Slip correction factor [unitless], SeP97 p. 464
+  !======================================================
+  real(r8) function slip_correction_factor( mean_free_path, particle_radius ) 
+
+    real(r8),intent(in) :: mean_free_path
+    real(r8),intent(in) :: particle_radius
+
+    slip_correction_factor = 1.0_r8 + mean_free_path * &
+                             ( 1.257_r8+0.4_r8*exp(-1.1_r8*particle_radius/mean_free_path) ) / &
+                             particle_radius
+
+  end function slip_correction_factor
 
 end module modal_aero_drydep

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -13,7 +13,7 @@ module modal_aero_drydep
   use ppgrid,         only: pcols, pver, pverp
   use modal_aero_data,only: ntot_amode
   use aerodep_flx,    only: aerodep_flx_prescribed
-  use physconst,      only: gravit, rair, rhoh2o
+  use physconst,      only: gravit, rair, rhoh2o, pi, boltz
   use camsrfexch,     only: cam_in_t, cam_out_t
   use physics_types,  only: physics_state, physics_ptend, physics_ptend_init
   use physics_buffer, only: physics_buffer_desc
@@ -440,7 +440,6 @@ contains
                                      radius_part, density_part, sig_part, moment,  &! in
                                      vlc_dry, vlc_trb, vlc_grv                     )! out
 
-    use physconst,     only: pi,boltz, gravit, rair
 
     integer,  intent(in) :: moment       ! moment of size distribution (0 for number, 2 for surface area, 3 for volume)
     integer,  intent(in) :: ncol         ! # of grid columns to do calculations for
@@ -467,8 +466,7 @@ contains
     !------------------------------------------------------------------------------------
     ! Calculate deposition velocity of gravitational settling in all grid layers
     !------------------------------------------------------------------------------------
-    call modal_aero_gravit_settling_velocity( moment, ncol, pcols, pver,                       &! in
-                                              gravit, rair, pi, radius_max,                    &! in
+    call modal_aero_gravit_settling_velocity( moment, ncol, pcols, pver, radius_max,           &! in
                                               tair, pmid, radius_part, density_part, sig_part, &! in
                                               vlc_grv                                          )! out
 
@@ -480,8 +478,7 @@ contains
     !  - Calculate turbulent dry deposition velocity, vlc_trb.
     !  - Add vlc_trb to vlc_grv to give the total deposition velocity, vlc_dry.
     !------------------------------------------------------------------------------------
-    call modal_aero_turb_drydep_velocity( moment, ncol, pcols, lchnk,                &! in
-                                          gravit, rair, pi, boltz, radius_max,       &! in
+    call modal_aero_turb_drydep_velocity( moment, ncol, pcols, lchnk, radius_max,    &! in
                                           tair(:,pver), pmid(:,pver),                &! in
                                           radius_part(:,pver), density_part(:,pver), &! in
                                           sig_part(:,pver),                          &! in
@@ -618,11 +615,9 @@ contains
   !==========================================================================
   ! Calculate particle velocity of gravitational settling
   !==========================================================================
-  subroutine modal_aero_gravit_settling_velocity( moment, ncol, pcols, nver,           &! in
-                                                  gravit, rair, pi, radius_max,        &! in
-                                                  tair, pmid,                          &! in
-                                                  radius_part, density_part, sig_part, &! in
-                                                  vlc_grv                              )! out
+  subroutine modal_aero_gravit_settling_velocity( moment, ncol, pcols, nver, radius_max,           &! in
+                                                  tair, pmid, radius_part, density_part, sig_part, &! in
+                                                  vlc_grv                                          )! out
 
     ! Arguments
 
@@ -631,9 +626,6 @@ contains
     integer,  intent(in) :: pcols        ! dimension size (# of columns) 
     integer,  intent(in) :: nver         ! dimension size (# of model layers) 
 
-    real(r8), intent(in) :: gravit            ! gravitational acceleration, [kg/m2/s]
-    real(r8), intent(in) :: rair              ! gas constant of air [J/K/kg]
-    real(r8), intent(in) :: pi                ! constant pi = 3.14159....
     real(r8), intent(in) :: radius_max        ! upper bound of radius used for the calculation of deposition velocity [m]
 
     real(r8), intent(in) :: tair(pcols,nver)    ! air temperature [K]
@@ -674,12 +666,11 @@ contains
   ! Calculate particle velocity of turbulent dry deposition.
   ! This process is assumed to only occur in the lowest model layer.
   !------------------------------------------------------------------------------------
-  subroutine modal_aero_turb_drydep_velocity( moment, ncol, pcols, lchnk,           &! in
-                                              gravit, rair, pi, boltz, radius_max,  &! in
-                                              tair, pmid,                           &! in
-                                              radius_part, density_part, sig_part,  &! in
-                                              fricvel, ram1, vlc_grv,               &! in
-                                              vlc_trb, vlc_dry                      )! out
+  subroutine modal_aero_turb_drydep_velocity( moment, ncol, pcols, lchnk, radius_max,  &! in
+                                              tair, pmid,                              &! in
+                                              radius_part, density_part, sig_part,     &! in
+                                              fricvel, ram1, vlc_grv,                  &! in
+                                              vlc_trb, vlc_dry                         )! out
 
     use mo_drydep,     only: n_land_type, fraction_landuse
 
@@ -690,10 +681,6 @@ contains
     integer,  intent(in) :: pcols            ! dimension size (# of grid columns)
     integer,  intent(in) :: lchnk            ! index of grid chunk
 
-    real(r8), intent(in) :: gravit           ! gravitational acceleration, [kg/m2/s]
-    real(r8), intent(in) :: rair             ! gas constant of air [J/K/kg]
-    real(r8), intent(in) :: pi               ! constant pi = 3.14159....
-    real(r8), intent(in) :: boltz            ! Boltzman's constant [J/K/molecule] 
     real(r8), intent(in) :: radius_max       ! upper bound of radius used for the calculation of deposition velocity [m]
 
     real(r8), intent(in) :: tair(pcols)      ! air temperature [K]

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -536,8 +536,7 @@ contains
           ! Size-independent thermokinetic properties
 
           vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
-          mfp_atm(ii,kk) = 2.0_r8 * vsc_dyn_atm(ii,kk) / &   ![m] SeP97 p. 455
-                          ( pmid(ii,kk)*sqrt(8.0_r8/(pi*rair*tair(ii,kk))) )
+          mfp_atm(ii,kk) = air_mean_free_path( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi )
           vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
 
           slp_crc(ii,kk) = 1.0_r8 + mfp_atm(ii,kk) * &
@@ -743,8 +742,23 @@ real(r8) function air_dynamic_viscosity( temp )
   real(r8),intent(in) :: temp   ! air temperature [K]
 
   air_dynamic_viscosity = 1.72e-5_r8 * ( (temp/273.0_r8)**1.5_r8) * 393.0_r8 &
-                                        /(temp+120.0_r8)  
+                                        /(temp+120.0_r8)
 
 end function air_dynamic_viscosity
+
+!==========================================================================
+! Calculate mean free path of air, unit [m]. See SeP97 p. 455
+!==========================================================================
+real(r8) function air_mean_free_path( dyn_visc, pres, temp, rair, pi )
+
+  real(r8),intent(in) :: dyn_visc  ! dynamic viscosity of air [kg m-1 s-1]
+  real(r8),intent(in) :: pres      ! air pressure [Pa]
+  real(r8),intent(in) :: temp      ! air temperature [K]
+  real(r8),intent(in) :: rair      ! gas constant of air [J/K/kg]
+  real(r8),intent(in) :: pi        ! constant pi = 3.14159....
+
+  air_mean_free_path = 2.0_r8*dyn_visc/( pres*sqrt( 8.0_r8/(pi*rair*temp) ) )
+
+end function air_mean_free_path
 
 end module modal_aero_drydep

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -93,12 +93,19 @@ contains
     real(r8) ::  dens_aer(pcols,pver)  ! wet density of interstitial aerosols [kg/m3]
     real(r8) ::    sg_aer(pcols,pver)  ! assumed geometric standard deviation of particle size distribution
 
-    real(r8) :: vlc_dry(pcols,pver,4)     ! dep velocity [m/s]
-    real(r8) :: vlc_grv(pcols,pver,4)     ! dep velocity [m/s]
-    real(r8)::  vlc_trb(pcols,4)          ! dep velocity [m/s]
-
     real(r8) :: aerdepdryis(pcols,pcnst)  ! surface deposition flux of interstitial aerosols, [kg/m2/s] or [1/m2/s]
     real(r8) :: aerdepdrycw(pcols,pcnst)  ! surface deposition flux of cloud-borne  aerosols, [kg/m2/s] or [1/m2/s]
+
+    ! Deposition velocities. The last dimension (size = 4) corresponds to the
+    ! two attachment states and two moments:
+    !   1 - interstitial aerosol, 0th moment (i.e., number)
+    !   2 - interstitial aerosol, 3rd moment (i.e., volume/mass)
+    !   3 - cloud-borne aerosol,  0th moment (i.e., number)
+    !   4 - cloud-borne aerosol,  3rd moment (i.e., volume/mass)
+
+    real(r8) :: vlc_grv(pcols,pver,4)     ! dep velocity of gravitational settling [m/s]
+    real(r8)::  vlc_trb(pcols,4)          ! dep velocity of turbulent dry deposition [m/s]
+    real(r8) :: vlc_dry(pcols,pver,4)     ! dep velocity, sum of vlc_grv and vlc_trb [m/s]
 
     ! The pointers below are used for retrieving information from pbuf
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -62,16 +62,16 @@ contains
     real(r8), pointer :: landfrac(:) ! land fraction [unitless]
     real(r8), pointer :: icefrac(:)  ! ice fraction [unitless]
     real(r8), pointer :: ocnfrac(:)  ! ocean fraction [unitless]
-    real(r8), pointer :: fricvelin(:)! friction velocity [m/s] from land model
-    real(r8), pointer :: ram1in(:)   ! aerodynamical resistance [s/m] from land model 
+    real(r8), pointer :: fricvelin(:)! friction velocity from land model [m/s]
+    real(r8), pointer :: ram1in(:)   ! aerodynamical resistance from land model [s/m]
 
     real(r8), pointer :: tair(:,:)   ! air temperture [k]
     real(r8), pointer :: pmid(:,:)   ! air pressure at layer midpoint [Pa]
     real(r8), pointer :: pint(:,:)   ! air pressure at layer interface [Pa]
     real(r8), pointer :: pdel(:,:)   ! layer thickness [Pa]
 
-    real(r8) :: fricvel(pcols)     ! friction velocity [m/s] used in the calculaiton of turbulent dry deposition velocity 
-    real(r8) ::    ram1(pcols)     ! aerodynamical resistance [s/m] used in the calculaiton of turbulent dry deposition velocity 
+    real(r8) :: fricvel(pcols)     ! friction velocity used in the calculaiton of turbulent dry deposition velocity [m/s]
+    real(r8) ::    ram1(pcols)     ! aerodynamical resistance used in the calculaiton of turbulent dry deposition velocity [s/m]
 
     integer :: lchnk   ! chunk identifier
     integer :: ncol    ! number of active atmospheric columns
@@ -89,7 +89,7 @@ contains
     real(r8) :: dens_drop(pcols,pver)  ! cloud droplet density [kg/m3]
     real(r8) ::   sg_drop(pcols,pver)  ! assumed geometric standard deviation of droplet size distribution
 
-    real(r8) ::   rad_aer(pcols,pver)  ! volume mean wet radius [m] of interstitial aerosols
+    real(r8) ::   rad_aer(pcols,pver)  ! volume mean wet radius of interstitial aerosols [m]
     real(r8) ::  dens_aer(pcols,pver)  ! wet density of interstitial aerosols [kg/m3]
     real(r8) ::    sg_aer(pcols,pver)  ! assumed geometric standard deviation of particle size distribution
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -528,25 +528,13 @@ contains
     do kk=1,pver
     do ii=1,ncol
        vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
-    enddo
-    enddo
 
-    do kk=1,pver
-    do ii=1,ncol
        lnsig = log(sig_part(ii,kk))
        radius_moment(ii,kk) = min(radiaus_max,radius_part(ii,kk))*exp((float(moment)-1.5_r8)*lnsig*lnsig)
-    enddo
-    enddo
 
-    do kk=1,pver
-    do ii=1,ncol
        slp_crc(ii,kk) = slip_correction_factor( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi, &
                                                 radius_moment(ii,kk) ) 
-    enddo
-    enddo
 
-    do kk=1,pver
-    do ii=1,ncol
        lnsig = log(sig_part(ii,kk))
        dispersion = exp(2._r8*lnsig*lnsig)
        vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment(ii,kk), density_part(ii,kk), &
@@ -564,8 +552,15 @@ contains
     kk = pver
 
     do ii=1,ncol
+       vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
+
        rho=pmid(ii,kk)/rair/tair(ii,kk)
        vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
+
+       lnsig = log(sig_part(ii,kk))
+       radius_moment(ii,kk) = min(radiaus_max,radius_part(ii,kk))*exp((float(moment)-1.5_r8)*lnsig*lnsig)
+       slp_crc(ii,kk) = slip_correction_factor( vsc_dyn_atm(ii,kk), pmid(ii,kk), tair(ii,kk), rair, pi, &
+                                                radius_moment(ii,kk) ) 
     enddo
 
     do ii=1,ncol

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -773,12 +773,12 @@ contains
 
     do ii=1,ncol
 
+       radius_moment = radius_for_moment( moment,sig_part(ii),radius_part(ii),radius_max )
+
        vsc_dyn_atm = air_dynamic_viscosity( tair(ii) )
 
-       rho=pmid(ii)/rair/tair(ii)
-       vsc_knm_atm = vsc_dyn_atm/rho ![m2 s-1] Kinematic viscosity of air
+       vsc_knm_atm = air_kinematic_viscosity( tair(ii), pmid(ii), rair )
 
-       radius_moment = radius_for_moment( moment,sig_part(ii),radius_part(ii),radius_max )
        slp_crc = slip_correction_factor( vsc_dyn_atm, pmid(ii), tair(ii), rair, pi, radius_moment ) 
 
        dff_aer = boltz * tair(ii) * slp_crc / (6.0_r8*pi*vsc_dyn_atm*radius_moment) 
@@ -856,6 +856,25 @@ contains
 
   end function air_dynamic_viscosity
 
+  !==========================================================================
+  ! Calculate kinematic viscosity of air, unit [m2 s-1]
+  !==========================================================================
+  real(r8) function air_kinematic_viscosity( temp, pres, rair )
+
+    real(r8),intent(in) :: temp   ! air temperature [K]
+    real(r8),intent(in) :: pres   ! air pressure [Pa]
+    real(r8),intent(in) :: rair   ! gas constant of air [J/K/kg]
+
+    real(r8) :: vsc_dyn_atm  ! kinematic viscosity of air [m2 s-1]
+    real(r8) :: rho          ! density of air [kg/m3]
+
+    vsc_dyn_atm = air_dynamic_viscosity( temp)
+    rho = pres/rair/temp
+
+    air_kinematic_viscosity = vsc_dyn_atm/rho
+
+  end function air_kinematic_viscosity
+
   !======================================================
   ! Slip correction factor [unitless], SeP97 p. 464
   !======================================================
@@ -868,7 +887,7 @@ contains
     real(r8),intent(in) :: pi               ! constant pi = 3.14159....
     real(r8),intent(in) :: particle_radius  ! particle radius [m]
 
-    real(r8) :: mean_free_path
+    real(r8) :: mean_free_path  ! [m]
 
     mean_free_path = 2.0_r8*dyn_visc/( pres*sqrt( 8.0_r8/(pi*rair*temp) ) )
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -344,14 +344,14 @@ contains
 
     do kk = 2,pver
        dtmassflux(:ncol,kk) = max(0._r8, dtmassflux(:ncol,kk))
-    end do
+    enddo
 
     ! Set values for the upper and lower boundaries
 
     do ii = 1,ncol
        dtmassflux(ii,1)     = 0                                         ! no flux at model top 
        dtmassflux(ii,pverp) = qq_in(ii,pver) * pvmzaer(ii,pverp) * dt   ! surface flux by upwind scheme
-    end do
+    enddo
 
     ! Limit the flux out of the bottom of each column:
     ! apply mxsedfac to prevent generating very small negative mixing ratio.
@@ -360,8 +360,8 @@ contains
     do kk = 1,pver
        do ii = 1,ncol
           dtmassflux(ii,kk+1) = min( dtmassflux(ii,kk+1), mxsedfac * qq_in(ii,kk) * pdel(ii,kk))
-       end do
-    end do
+       enddo
+    enddo
 
     !-----------------------------------------------------------------------
     ! Calculate the mixing ratio tendencies resulting from flux divergence
@@ -369,8 +369,8 @@ contains
     do kk = 1,pver
        do ii = 1,ncol
           dqdt_sed(ii,kk)  = (dtmassflux(ii,kk) - dtmassflux(ii,kk+1)) / (dt * pdel(ii,kk))
-       end do
-    end do
+       enddo
+    enddo
 
     !-----------------------------------------------------------------------
     ! Convert flux out the bottom to mass units [kg/m2/s]

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -640,9 +640,9 @@ contains
     ! Local Variables
 
     integer  :: ii, kk        ! grid column and layer indices
-    real(r8) :: vsc_dyn_atm   ! [kg m-1 s-1] Dynamic viscosity of air
-    real(r8) :: slp_crc       ! [frc] Slip correction factor
-    real(r8) :: radius_moment ! median radius [m] for moment
+    real(r8) :: vsc_dyn_atm   ! Dynamic viscosity of air [kg m-1 s-1]
+    real(r8) :: slp_crc       ! Slip correction factor [unitless]
+    real(r8) :: radius_moment ! median radius for moment [m]
 
     !-----------
     do kk=1,nver
@@ -701,15 +701,15 @@ contains
     ! Local Variables
 
     integer  :: ii            ! grid column index
-    real(r8) :: vsc_dyn_atm   ! [kg m-1 s-1] Dynamic viscosity of air
-    real(r8) :: vsc_knm_atm   ! [m2 s-1] Kinematic viscosity of atmosphere
-    real(r8) :: slp_crc       ! [frc] Slip correction factor
-    real(r8) :: radius_moment ! median radius [m] for moment
+    real(r8) :: vsc_dyn_atm   ! Dynamic viscosity of air [kg m-1 s-1]
+    real(r8) :: vsc_knm_atm   ! Kinematic viscosity of atmosphere [m2 s-1]
+    real(r8) :: slp_crc       ! Slip correction factor [unitless]
+    real(r8) :: radius_moment ! median radius for moment [m]
 
-    real(r8) :: shm_nbr       ! [frc] Schmidt number
-    real(r8) :: stk_nbr       ! [frc] Stokes number
-    real(r8) :: rss_trb       ! [s m-1] Resistance to turbulent deposition
-    real(r8) :: rss_lmn       ! [s m-1] Quasi-laminar layer resistance
+    real(r8) :: shm_nbr       ! Schmidt number [unitless]
+    real(r8) :: stk_nbr       ! Stokes number [unitless]
+    real(r8) :: rss_trb       ! Resistance to turbulent deposition [s m-1]
+    real(r8) :: rss_lmn       ! Quasi-laminar layer resistance [s m-1]
     real(r8) :: brownian      ! collection efficiency for Browning diffusion
     real(r8) :: impaction     ! collection efficiency for impaction
     real(r8) :: interception  ! collection efficiency for interception
@@ -799,7 +799,7 @@ contains
              if (radius_collector(lt) > 0.0_r8) then ! vegetated surface
                 stk_nbr = vlc_grv(ii) * fricvel(ii) / (gravit*radius_collector(lt))
              else ! non-vegetated surface
-                stk_nbr = vlc_grv(ii) * fricvel(ii) * fricvel(ii) / (gravit*vsc_knm_atm)  ![frc] SeP97 p.965
+                stk_nbr = vlc_grv(ii) * fricvel(ii) * fricvel(ii) / (gravit*vsc_knm_atm)  ! SeP97 p.965
              endif
 
              impaction = (stk_nbr/(alpha(lt)+stk_nbr))**beta   ! Eq. (7c) of Zhang L. et al.  (2001)
@@ -881,7 +881,7 @@ contains
     real(r8),intent(in) :: pres   ! air pressure [Pa]
     real(r8),intent(in) :: rair   ! gas constant of air [J/K/kg]
 
-    real(r8) :: vsc_dyn_atm  ! kinematic viscosity of air [m2 s-1]
+    real(r8) :: vsc_dyn_atm  ! dynamic viscosity of air [kg m-1 s-1]
     real(r8) :: rho          ! density of air [kg/m3]
 
     vsc_dyn_atm = air_dynamic_viscosity( temp)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -53,7 +53,6 @@ contains
     type(physics_ptend),    intent(out)   :: ptend     ! indivdual parameterization tendencies
     type(physics_buffer_desc),    pointer :: pbuf(:)
 
-  ! local vars
     real(r8), pointer :: landfrac(:) ! land fraction
     real(r8), pointer :: icefrac(:)  ! ice fraction
     real(r8), pointer :: ocnfrac(:)  ! ocean fraction
@@ -64,6 +63,8 @@ contains
     real(r8), pointer :: pmid(:,:)   ! air pressure at layer midpoint [Pa]
     real(r8), pointer :: pint(:,:)   ! air pressure at layer interface [Pa]
     real(r8), pointer :: pdel(:,:)   ! layer thickness [Pa]
+
+  ! local vars
 
     real(r8) :: fv(pcols)            ! for dry dep velocities, from land modified over ocean & ice
     real(r8) :: ram1(pcols)          ! for dry dep velocities, from land modified over ocean & ice
@@ -531,11 +532,10 @@ contains
 
           rho=pmid(ii,kk)/rair/tair(ii,kk)
 
-          ! Quasi-laminar layer resistance: call rss_lmn_get
+          ! Quasi-laminar layer resistance: 
           ! Size-independent thermokinetic properties
 
-          vsc_dyn_atm(ii,kk) = 1.72e-5_r8 * ( (tair(ii,kk)/273.0_r8)**1.5_r8) * 393.0_r8 &
-                                             /(tair(ii,kk)+120.0_r8)  ![kg m-1 s-1] RoY94 p. 102
+          vsc_dyn_atm(ii,kk) = air_dynamic_viscosity( tair(ii,kk) )
           mfp_atm(ii,kk) = 2.0_r8 * vsc_dyn_atm(ii,kk) / &   ![m] SeP97 p. 455
                           ( pmid(ii,kk)*sqrt(8.0_r8/(pi*rair*tair(ii,kk))) )
           vsc_knm_atm(ii,kk) = vsc_dyn_atm(ii,kk) / rho ![m2 s-1] Kinematic viscosity of air
@@ -550,6 +550,8 @@ contains
 
        enddo
     enddo
+
+
     vlc_dry(:ncol,:)=vlc_grv(:ncol,:)
 
     !------------------------------------------------------------------------------------
@@ -732,5 +734,17 @@ contains
      enddo ! loop over grid columns
 
   end subroutine calcram
+
+!==========================================================================
+! Calculate dynamic viscosity of air, unit [kg m-1 s-1]. See RoY94 p. 102
+!==========================================================================
+real(r8) function air_dynamic_viscosity( temp )
+
+  real(r8),intent(in) :: temp   ! air temperature [K]
+
+  air_dynamic_viscosity = 1.72e-5_r8 * ( (temp/273.0_r8)**1.5_r8) * 393.0_r8 &
+                                        /(temp+120.0_r8)  
+
+end function air_dynamic_viscosity
 
 end module modal_aero_drydep

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -651,7 +651,7 @@ contains
 
        radius_moment = radius_for_moment( moment,sig_part(ii,kk),radius_part(ii,kk),radius_max )
 
-       slp_crc = slip_correction_factor( vsc_dyn_atm, pmid(ii,kk), tair(ii,kk), rair, pi, radius_moment ) 
+       slp_crc = slip_correction_factor( vsc_dyn_atm, pmid(ii,kk), tair(ii,kk), radius_moment ) 
 
        vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment, density_part(ii,kk),   &
                                                   slp_crc, vsc_dyn_atm, sig_part(ii,kk) )
@@ -756,12 +756,12 @@ contains
        ! Calculate size-INdependent thermokinetic properties of the air
 
        vsc_dyn_atm = air_dynamic_viscosity( tair(ii) )
-       vsc_knm_atm = air_kinematic_viscosity( tair(ii), pmid(ii), rair )
+       vsc_knm_atm = air_kinematic_viscosity( tair(ii), pmid(ii) )
 
        ! Calculate the mean radius and Schmidt number of the moment
 
        radius_moment = radius_for_moment( moment,sig_part(ii),radius_part(ii),radius_max )
-       shm_nbr = schmidt_number( tair(ii), pmid(ii), radius_moment, rair, pi, boltz, vsc_dyn_atm, vsc_knm_atm )
+       shm_nbr = schmidt_number( tair(ii), pmid(ii), radius_moment, vsc_dyn_atm, vsc_knm_atm )
 
        ! Initialize deposition velocities averages over different land surface types
 
@@ -874,11 +874,10 @@ contains
   !==========================================================================
   ! Calculate kinematic viscosity of air, unit [m2 s-1]
   !==========================================================================
-  real(r8) function air_kinematic_viscosity( temp, pres, rair )
+  real(r8) function air_kinematic_viscosity( temp, pres )
 
     real(r8),intent(in) :: temp   ! air temperature [K]
     real(r8),intent(in) :: pres   ! air pressure [Pa]
-    real(r8),intent(in) :: rair   ! gas constant of air [J/K/kg]
 
     real(r8) :: vsc_dyn_atm  ! dynamic viscosity of air [kg m-1 s-1]
     real(r8) :: rho          ! density of air [kg/m3]
@@ -895,13 +894,11 @@ contains
   ! See, e.g., SeP97 p. 464 and Zhang L. et al. (2001),
   ! DOI: 10.1016/S1352-2310(00)00326-5, Eq. (3).
   !======================================================
-  real(r8) function slip_correction_factor( dyn_visc, pres, temp, rair, pi, particle_radius ) 
+  real(r8) function slip_correction_factor( dyn_visc, pres, temp, particle_radius ) 
 
     real(r8),intent(in) :: dyn_visc         ! dynamic viscosity of air [kg m-1 s-1]
     real(r8),intent(in) :: pres             ! air pressure [Pa]
     real(r8),intent(in) :: temp             ! air temperature [K]
-    real(r8),intent(in) :: rair             ! gas constant of air [J/K/kg]
-    real(r8),intent(in) :: pi               ! constant pi = 3.14159....
     real(r8),intent(in) :: particle_radius  ! particle radius [m]
 
     real(r8) :: mean_free_path  ! [m]
@@ -917,21 +914,18 @@ contains
   !====================================================================
   ! Calculate the Schmidt number of air [unitless], see SeP97 p.972
   !====================================================================
-  real(r8) function schmidt_number( temp, pres, radius, rair, pi, boltz, vsc_dyn_atm, vsc_knm_atm )
+  real(r8) function schmidt_number( temp, pres, radius, vsc_dyn_atm, vsc_knm_atm )
 
     real(r8),intent(in) :: temp             ! air temperature [K]
     real(r8),intent(in) :: pres             ! air pressure [Pa]
     real(r8),intent(in) :: radius           ! particle radius [m]
-    real(r8),intent(in) :: rair             ! gas constant of air [J/K/kg]
-    real(r8),intent(in) :: pi               ! constant pi = 3.14159....
-    real(r8),intent(in) :: boltz            ! Boltzman's constant [J/K/molecule] 
     real(r8),intent(in) :: vsc_dyn_atm      ! dynamic viscosity of air [kg m-1 s-1]
     real(r8),intent(in) :: vsc_knm_atm      ! kinematic viscosity of air [m2 s-1]
 
     real(r8) :: slp_crc   ! slip correction factor [unitless]
     real(r8) :: dff_aer   ! Brownian diffusivity of particle [m2/s], see SeP97 p.474
 
-    slp_crc = slip_correction_factor( vsc_dyn_atm, pres, temp, rair, pi, radius )
+    slp_crc = slip_correction_factor( vsc_dyn_atm, pres, temp, radius )
     dff_aer = boltz * temp * slp_crc / (6.0_r8*pi*vsc_dyn_atm*radius) 
 
     schmidt_number = vsc_knm_atm / dff_aer

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -195,7 +195,7 @@ contains
 
        qq => qqcw_get_field(pbuf,icnst,lchnk)
        call sedimentation_solver_for_1_tracer( ncol, dt, vlc_dry(:,:,jvlc), qq,    &! in
-                                               gravit, rho, tair, pint, pmid, pdel,&! in
+                                               rho, tair, pint, pmid, pdel,        &! in
                                                dqdt_tmp, sflx                      )! out
 
        aerdepdrycw(:ncol,icnst) = sflx(:ncol)
@@ -257,7 +257,7 @@ contains
 
           qq => state%q(:,:,icnst)
           call sedimentation_solver_for_1_tracer( ncol, dt, vlc_dry(:,:,jvlc), qq,    &! in
-                                                  gravit, rho, tair, pint, pmid, pdel,&! in
+                                                  rho, tair, pint, pmid, pdel,        &! in
                                                   dqdt_tmp, sflx                      )! out
 
           aerdepdryis(:ncol,icnst) = sflx(:ncol)
@@ -291,7 +291,7 @@ contains
   ! Numerically solve the sedimentation equation for 1 tracer
   !-----------------------------------------------------------------------
   subroutine sedimentation_solver_for_1_tracer( ncol, dt, sed_vel, qq_in,            &! in
-                                                gravit, rho, tair, pint, pmid, pdel, &! in
+                                                rho, tair, pint, pmid, pdel,         &! in
                                                 dqdt_sed, sflx                       )! out
 
     use shr_kind_mod,      only: r8 => shr_kind_r8
@@ -300,7 +300,6 @@ contains
 
     integer , intent(in) :: ncol
     real(r8), intent(in) :: dt
-    real(r8), intent(in) :: gravit                    ! gravitational acceleration [m/s2]
     real(r8), intent(in) :: rho(pcols,pver)           ! air density [kg/m3]
     real(r8), intent(in) :: tair(pcols,pver)          ! air temperature [K]
     real(r8), intent(in) :: pint(pcols,pverp)         ! air pressure at layer interfaces [Pa]
@@ -654,8 +653,8 @@ contains
 
        slp_crc = slip_correction_factor( vsc_dyn_atm, pmid(ii,kk), tair(ii,kk), rair, pi, radius_moment ) 
 
-       vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment, density_part(ii,kk),      &
-                                                  gravit, slp_crc, vsc_dyn_atm, sig_part(ii,kk) )
+       vlc_grv(ii,kk) = gravit_settling_velocity( radius_moment, density_part(ii,kk),   &
+                                                  slp_crc, vsc_dyn_atm, sig_part(ii,kk) )
     enddo
     enddo
     !----
@@ -940,18 +939,17 @@ contains
   end function schmidt_number
 
   !=======================================================================================
-  ! Calculate the bulk gravitational settling velocity [m/s-1] 
+  ! Calculate the bulk gravitational settling velocity [m s-1] 
   !  - using the terminal velocity of sphere falling in a fluid based on Stokes's law and 
   !  - taking into account the influces of size distribution.
   !=======================================================================================
-  real(r8) function gravit_settling_velocity( particle_radius, particle_density, gravit,       &
+  real(r8) function gravit_settling_velocity( particle_radius, particle_density,               &
                                               slip_correction, dynamic_viscosity, particle_sig )
 
     real(r8),intent(in) :: particle_radius   ! [m]
     real(r8),intent(in) :: particle_density  ! [kg/m3]
-    real(r8),intent(in) :: gravit            ! [kg/m2/s], gravitational acceleration
     real(r8),intent(in) :: slip_correction   ! [unitless]
-    real(r8),intent(in) :: dynamic_viscosity ! [kg/m/s], dynamic viscosity of air
+    real(r8),intent(in) :: dynamic_viscosity ! [kg/m/s]
     real(r8),intent(in) :: particle_sig      ! geometric standard deviation of particle size distribution
 
     real(r8) :: lnsig         ! ln(particle_sig)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_drydep.F90
@@ -12,7 +12,6 @@ module modal_aero_drydep
   use modal_aero_data,only: cnst_name_cw
   use ppgrid,         only: pcols, pver, pverp
   use modal_aero_data,only: ntot_amode
-  use aerodep_flx,    only: aerodep_flx_prescribed
   use physconst,      only: gravit, rair, rhoh2o, pi, boltz
   use camsrfexch,     only: cam_in_t, cam_out_t
   use physics_types,  only: physics_state, physics_ptend, physics_ptend_init
@@ -284,13 +283,10 @@ contains
     enddo    ! imode = 1, ntot_amode
 
     !=====================================================================
-    ! Unless the user has specified prescribed aerosol dep fluxes,
-    ! copy the fluxes calculated here to cam_out to be passed to other 
+    ! Copy the fluxes calculated here to cam_out to be passed to other
     ! components of the Earth System Model.
     !=====================================================================
-    if (.not.aerodep_flx_prescribed()) then
-       call set_srf_drydep(aerdepdryis, aerdepdrycw, cam_out)
-    endif
+    call set_srf_drydep(aerdepdryis, aerdepdrycw, cam_out)
 
   end subroutine aero_model_drydep
 


### PR DESCRIPTION
This PR contains the following changes:
- Following @mingxuanwupnnl's suggestion, the calculations of gravitational settling velocity and turbulent dry deposition velocity are wrapped into two subroutines.
- A number of Fortran functions are added for the calculations of various size-dependent and -independent kinematic properties.
- Comments are added to explain the flow of calculations and references.
- Some other minor edits.