### PR TITLE
refactor subroutine calc_1_impact_rate

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1829,11 +1829,8 @@ do_lphase2_conditional: &
    rhoair = 28.966_r8*cair
    !   molecular freepath [cm]
    freepath = 2.8052e-10_r8/cair
-   !   air dynamic viscosity
-   airdynvisc = 1.8325e-4_r8 * (416.16_r8/(temp+120._r8)) *    &
-        ((temp/296.16_r8)**1.5_r8)
    !   air kinematic viscosity
-   airkinvisc = airdynvisc/rhoair
+   airkinvisc = air_kinematic_viscosity( temp, rhoair )
    !   ratio of water viscosity to air viscosity (from Slinn)
    xmuwaterair = 60.0_r8
 
@@ -2152,5 +2149,39 @@ do_lphase2_conditional: &
     enddo
 
   end subroutine vmr2qqcw
+
+  !=============================================================================
+  real(r8) function air_dynamic_viscosity( temp )
+    !-----------------------------------------------------------------
+    ! Calculate dynamic viscosity of air, unit [g/cm/s]
+    !
+    ! note that this calculation is different with that used in dry deposition
+    ! see the same-name function in modal_aero_drydep.F90 
+    !-----------------------------------------------------------------
+
+    real(r8),intent(in) :: temp   ! air temperature [K]
+
+    air_dynamic_viscosity = 1.8325e-4_r8 * (416.16_r8/(temp+120._r8)) *    &
+                            ((temp/296.16_r8)**1.5_r8)
+
+  end function air_dynamic_viscosity
+
+  !=============================================================================
+  real(r8) function air_kinematic_viscosity( temp, rhoair )
+    !-----------------------------------------------------------------
+    ! Calculate kinematic viscosity of air, unit [cm^2/s]
+    !-----------------------------------------------------------------
+
+    real(r8),intent(in) :: temp     ! air temperature [K]
+    real(r8),intent(in) :: rhoair   ! air density [g/cm2]
+
+    real(r8) :: vsc_dyn_atm  ! dynamic viscosity of air [g/cm/s]
+
+    vsc_dyn_atm = air_dynamic_viscosity( temp)
+    air_kinematic_viscosity = vsc_dyn_atm/rhoair
+
+  end function air_kinematic_viscosity
+
+  !=============================================================================
 
 end module aero_model

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1784,7 +1784,7 @@ do_lphase2_conditional: &
    real(r8) :: cair                     ! air molar density [dyne/cm^2/erg*mol = mol/cm^3]
    real(r8) :: rhoair                   ! air mass density [g/cm^3]
    real(r8) :: rlo, rhi, dr             ! rain droplet bin information [cm]
-   real(r8) :: rainsweepout             ! rain droplet sweep out area [cm3/cm3/s]
+   real(r8) :: rainsweepout             ! rain droplet sweep out volume [cm3/cm3/s]
    real(r8) :: scavsumnum, scavsumnumbb ! scavenging rate of aerosol number, "*bb" is for each rain droplet radius bin [1/s] 
    real(r8) :: scavsumvol, scavsumvolbb ! scavenging rate of aerosol volume, "*bb" is for each rain droplet radius bin [1/s]
    real(r8) :: sx                       ! standard deviation (log-normal distribution)
@@ -2192,7 +2192,7 @@ do_lphase2_conditional: &
     !-----------------------------------------------------------------
 
     real(r8),intent(in) :: temp     ! air temperature [K]
-    real(r8),intent(in) :: rhoair   ! air density [g/cm2]
+    real(r8),intent(in) :: rhoair   ! air density [g/cm3]
 
     real(r8) :: vsc_dyn_atm  ! dynamic viscosity of air [g/cm/s]
 


### PR DESCRIPTION
refactor the subroutine calc_1_impact_rate in wet deposition (in aero_model.F90). 

break into small subroutines and functions.

Note that the calculation of Schmidt Number and air dynamic viscosity have similar functions in dry deposition (modal_aero_drydep.F90), but the equations are different. @huiwanpnnl Do you know if they are from different references or any other reason?