### PR TITLE
refactor below-cloud scavenging

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1600,8 +1600,7 @@ do_lphase2_conditional: &
     implicit none
 
     !   local variables
-    integer,parameter :: nnfit_maxd=27
-    integer :: jgrow, ll, imode, nnfit
+    integer :: jgrow, ll, imode
     integer :: lunerr
 
     ! set up temperature-pressure pair to compute impaction scavenging rates
@@ -1612,9 +1611,6 @@ do_lphase2_conditional: &
          rhodryaero, rhowetaero, rhowetaero_cgs, rmserr, &
          scavratenum, scavratevol, sigmag,                &
          temp, wetdiaratio, wetvolratio
-    real(r8) aafitnum(1), xxfitnum(1,nnfit_maxd), yyfitnum(nnfit_maxd)
-    real(r8) aafitvol(1), xxfitvol(1,nnfit_maxd), yyfitvol(nnfit_maxd)
-
     
     lunerr = 6
 
@@ -1635,8 +1631,6 @@ do_lphase2_conditional: &
           rhowetaero = min( rhowetaero, rhodryaero )
 
           !   compute impaction scavenging rates at 1 temp-press pair and save
-          nnfit = 0
-
           rhowetaero = rhodryaero
 
           dg0_cgs = dg0*1.0e2_r8   ! m to cm
@@ -1645,20 +1639,8 @@ do_lphase2_conditional: &
                dg0_cgs, sigmag, rhowetaero_cgs, temp_0C, press_750hPa, &
                scavratenum, scavratevol, lunerr )
 
-          nnfit = nnfit + 1
-          if (nnfit .gt. nnfit_maxd) then
-             write(lunerr,*), '*** subr. modal_aero_bcscavcoef_init -- nnfit too big'
-             call endrun()
-          endif
-
-          xxfitnum(1,nnfit) = 1._r8
-          yyfitnum(nnfit) = log( scavratenum )
-
-          xxfitvol(1,nnfit) = 1._r8
-          yyfitvol(nnfit) = log( scavratevol )
-
-          scavimptblnum(jgrow,imode) = yyfitnum(1)
-          scavimptblvol(jgrow,imode) = yyfitvol(1)
+          scavimptblnum(jgrow,imode) = log( scavratenum )
+          scavimptblvol(jgrow,imode) = log( scavratevol )
 
        enddo growloop
     enddo modeloop

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1607,10 +1607,10 @@ do_lphase2_conditional: &
     real(r8), parameter :: temp_0C = 273.16_r8        ! K
     real(r8), parameter :: press_750hPa = 0.75e6_r8   ! dynes/cm2
 
-    real(r8) :: dg0, dg0_cgs, press, &
-         rhodryaero, rhowetaero, rhowetaero_cgs, rmserr, &
+    real(r8) :: dg0, dg0_cgs, &
+         rhodryaero, rhowetaero, rhowetaero_cgs, &
          scavratenum, scavratevol, sigmag,                &
-         temp, wetdiaratio, wetvolratio
+         wetdiaratio, wetvolratio
     
     lunerr = 6
 
@@ -1630,9 +1630,17 @@ do_lphase2_conditional: &
           rhowetaero = 1.0_r8 + (rhodryaero-1.0_r8)/wetvolratio
           rhowetaero = min( rhowetaero, rhodryaero )
 
-          !   compute impaction scavenging rates at 1 temp-press pair and save
+! FIXME: not sure why wet aerosol density is set as dry aerosol density here
+! but the above calculation of rhowetaero is incorrect. 
+! I think the number 1.0_r8 should be 1000._r8 as the unit is kg/m3
+! the above calculation gives wet aerosol density very small number (a few kg/m3)
+! this may cause some problem. I guess this is the reason of using dry density.
+! should be better if fix the wet density bug and use it. Keep it for now for BFB testing
+! -- (commented by Shuaiqi Tang when refactoring for MAM4xx)
           rhowetaero = rhodryaero
 
+          ! compute impaction scavenging rates at 1 temp-press pair and save
+          ! note that the subroutine calc_1_impact_rate uses CGS units
           dg0_cgs = dg0*1.0e2_r8   ! m to cm
           rhowetaero_cgs = rhowetaero*1.0e-3_r8   ! kg/m3 to g/cm3
           call calc_1_impact_rate( &

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1659,28 +1659,32 @@ do_lphase2_conditional: &
 
   !===============================================================================
   subroutine modal_aero_bcscavcoef_get( m, ncol, isprx, dgn_awet, scavcoefnum, scavcoefvol )
+    !-----------------------------------------------------------------------
+    ! compute impaction scavenging removal amount for aerosol volume and number
+    !-----------------------------------------------------------------------
 
     use modal_aero_data, only: dgnum_amode
-    !-----------------------------------------------------------------------
+
     implicit none
 
-    integer,intent(in) :: m, ncol
-    logical,intent(in):: isprx(pcols,pver)
-    real(r8), intent(in) :: dgn_awet(pcols,pver,ntot_amode)
-    real(r8), intent(out) :: scavcoefnum(pcols,pver), scavcoefvol(pcols,pver)
+    integer,  intent(in) :: m, ncol
+    logical,  intent(in) :: isprx(pcols,pver)           ! if there is precip
+    real(r8), intent(in) :: dgn_awet(pcols,pver,ntot_amode)  ! wet aerosol diameter [m]
+    real(r8), intent(out):: scavcoefnum(pcols,pver)     ! scavenging removal for aerosol number [1/h]
+    real(r8), intent(out):: scavcoefvol(pcols,pver)     ! scavenging removal for aerosol volume [1/h]
 
-    integer i, k, jgrow
+    ! local variables
+    integer :: i, k, jgrow      ! index
     real(r8) dumdgratio, xgrow, dumfhi, dumflo, scavimpvol, scavimpnum
 
 
     do k = 1, pver
        do i = 1, ncol
 
-          ! do only if no precip
+          ! do only if there is precip
           if ( isprx(i,k) ) then
-             !
+             
              ! interpolate table values using log of (actual-wet-size)/(base-dry-size)
-
              dumdgratio = dgn_awet(i,k,m)/dgnum_amode(m)
 
              if ((dumdgratio .ge. 0.99_r8) .and. (dumdgratio .le. 1.01_r8)) then
@@ -1712,12 +1716,7 @@ do_lphase2_conditional: &
              ! impaction scavenging removal amount to number
              scavcoefnum(i,k) = exp( scavimpnum )
 
-             ! scavcoef = impaction scav rate (1/h) for precip = 1 mm/h
-             ! scavcoef = impaction scav rate (1/s) for precip = pfx_inrain
-             ! (scavcoef/3600) = impaction scav rate (1/s) for precip = 1 mm/h
-             ! (pfx_inrain*3600) = in-rain-area precip rate (mm/h)
-             ! impactrate = (scavcoef/3600) * (pfx_inrain*3600)
-          else
+          else ! if no precip
              scavcoefvol(i,k) = 0._r8
              scavcoefnum(i,k) = 0._r8
           endif

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1600,24 +1600,26 @@ do_lphase2_conditional: &
     implicit none
 
     !   local variables
-    integer :: jgrow, ll, imode
-    integer :: lunerr
+    integer :: jgrow, ll, imode ! indexes
+    integer :: lunerr           ! logical unit for error message
+    real(r8) :: dg0             ! aerosol diameter [m]
+    real(r8) :: dg0_cgs         ! aerosol diameter in CGS unit [cm]
+    real(r8) :: sigmag          ! standard deviation of aerosol size distribution 
+    real(r8) :: rhodryaero, rhowetaero   ! dry and wet aerosol density [kg/m3] 
+    real(r8) :: rhowetaero_cgs  ! wet aerosol density in CGS unit [g/cm3]
+    real(r8) :: scavratenum     ! scavenging rate of aerosol number [1/s]
+    real(r8) :: scavratevol     ! scavenging rate of aerosol volume [1/s]
+    real(r8) :: wetdiaratio, wetvolratio ! ratio of diameter and volume for wet/dry aerosols [fraction]
 
     ! set up temperature-pressure pair to compute impaction scavenging rates
     real(r8), parameter :: temp_0C = 273.16_r8        ! K
     real(r8), parameter :: press_750hPa = 0.75e6_r8   ! dynes/cm2
-
-    real(r8) :: dg0, dg0_cgs, &
-         rhodryaero, rhowetaero, rhowetaero_cgs, &
-         scavratenum, scavratevol, sigmag,                &
-         wetdiaratio, wetvolratio
     
     lunerr = 6
 
     modeloop: do imode = 1, ntot_amode
 
        sigmag = sigmag_amode(imode)
-
        ll = lspectype_amode(1,imode)
        rhodryaero = specdens_amode(ll)
 
@@ -1625,7 +1627,6 @@ do_lphase2_conditional: &
 
           wetdiaratio = exp( jgrow*dlndg_nimptblgrow )
           dg0 = dgnum_amode(imode)*wetdiaratio
-
           wetvolratio = exp( jgrow*dlndg_nimptblgrow*3._r8 )
           rhowetaero = 1.0_r8 + (rhodryaero-1.0_r8)/wetvolratio
           rhowetaero = min( rhowetaero, rhodryaero )
@@ -1653,6 +1654,7 @@ do_lphase2_conditional: &
        enddo growloop
     enddo modeloop
     return
+
   end subroutine modal_aero_bcscavcoef_init
 
   !===============================================================================


### PR DESCRIPTION
refactor two subroutines related to below-cloud scavenging: 
`modal_aero_bcscavcoef_init`
`modal_aero_bcscavcoef_get`

mainly removing unused code, clean up comments and variables.

One issue about the wet aerosol density `rhowetaero`: it is calculated but then assigned as the value of dry aerosol density `rhodryaero`. It looks that the calculation of `rhowetaero`  is incorrect (a number 1.0_r8 should be 1000._r8) so I guess this is a simple treatment to avoid incorrect wet density values. Made a comment on it.