### PR TITLE
Adds ncol to fix array mismatch error

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -79,6 +79,7 @@ _TESTS = {
             "ERS.ne4pg2_oQU480.F2010",
             "ERP_P64x1.ne4pg2_oQU480.F2010",
             "PET.ne4pg2_oQU480.F2010",
+            "SMS_D_Ln5_P1x1.ne4pg2_oQU480.F2010",
             "PEM_P64x1.ne4pg2_oQU480.F2010"
             )
         },

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1421,7 +1421,7 @@ do_lphase2_conditional: &
     do mm = 1,gas_pcnst
        fldcw => qqcw_get_field(pbuf, mm+loffset,lchnk,errorhandle=.true.)
        if(associated(fldcw)) then
-           fldcw_all(:,:,mm) = fldcw(:,:)
+           fldcw_all(:ncol,:,mm) = fldcw(:ncol,:)
        else
            fldcw_all(:,:,mm) = 0.0_r8
        endif
@@ -1482,7 +1482,7 @@ do_lphase2_conditional: &
     ! assign mass mixing ratio back to pbuf
     do mm = 1,gas_pcnst
        fldcw => qqcw_get_field(pbuf, mm+loffset,lchnk,errorhandle=.true.)
-       if(associated(fldcw))   fldcw = fldcw_all(:,:,mm)
+       if(associated(fldcw))   fldcw(:ncol,:) = fldcw_all(:ncol,:,mm)
     enddo
 
     ! diagnostics for cloud-borne aerosols... 


### PR DESCRIPTION
I ran the model with just one task (or proc or CPU) and got an error due to ncol and pcols mismatch. It is a simple fix. I will add a test to guard against these issues.