### PR TITLE
Unified write_var calls and automated writing variables

### DIFF
--- a/mam4_refactor_scripts/beg.inp
+++ b/mam4_refactor_scripts/beg.inp
@@ -42,16 +42,16 @@
 
   if(yaml%col_print == y_i .and. y_nstep==yaml%nstep_print .and. y_k == yaml%lev_print) then ! if this column exists in y_lchnk
 
-     !-----------------------------------------------------------------------------------------
-     !In the case of y_i or y_k are not passed as arguments, use the following if condition:
-     !if(yaml%col_print >0 .and. y_nstep==yaml%nstep_print) then
-     !-----------------------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------------------
+  !In the case of y_i or y_k are not passed as arguments, use the following if condition:
+  !if(yaml%col_print >0 .and. y_nstep==yaml%nstep_print) then
+  !-----------------------------------------------------------------------------------------
 
-     !-----------------------------------------------------------------------------------------
-     !For generating data for a dependent subroutines where "yaml" derived type is already
-     !initialized, use the following if condition
-     !if(yaml%flag_print) then
-     !-----------------------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------------------
+  !For generating data for a dependent subroutines where "yaml" derived type is already
+  !initialized, use the following if condition
+  !if(yaml%flag_print) then
+  !-----------------------------------------------------------------------------------------
 
      !-----------------------------------------------------------------------------------------
      ! Set "ext_str" if there are multiple sets of yaml output to be written out

--- a/mam4_refactor_scripts/beg.inp
+++ b/mam4_refactor_scripts/beg.inp
@@ -66,7 +66,7 @@
 
      if (n_calls==1) then ! output at the first call only, modify this if condition (see below) if writing out other calls
 
-        !if ((n_calls==1 .and. flag==0) .or. (n_calls==3 .and. flag==1) .or. (n_calls==5 .and. flag==2)) then
+     !if ((n_calls==1 .and. flag==0) .or. (n_calls==3 .and. flag==1) .or. (n_calls==5 .and. flag==2)) then
 
         !(**remove these yaml% variables if generating data for a dependent subroutines**)
         yaml%lchnk_print = y_lchnk

--- a/mam4_refactor_scripts/beg.inp
+++ b/mam4_refactor_scripts/beg.inp
@@ -1,69 +1,92 @@
 !#ifdef YAML_CPP
-  !<"lchnk" is needed for the following code to work,
+  !-----------------------------------------------------------------------------------------
+  !"lchnk" is needed for the following code to work,
   ! temporarily pass it along from upper level subroutines
   ! as y_lchnk and uncomment the following code:
   ! integer, intent(in) :: y_lchnk
+  !-----------------------------------------------------------------------------------------
 
+  !-----------------------------------------------------------------------------------------
   ! **OR** if this subroutine is called in a nested loop of columns and levels,
   ! we also might need column index (y_i or icol) and level
   ! index (y_k or klev) to be passed to this routine and
   ! uncomment the following code:
   ! integer, intent(in) :: y_i, y_k, y_lchnk
+  !-----------------------------------------------------------------------------------------
 
-  !>
+  !-----------------------------------------------------------------------------------------
+  ! This is used when multiple sets of yaml output is needed
+  !to cover different options (e.g., true and false)
+  ! character(len=200) :: ext_str
+  !-----------------------------------------------------------------------------------------
 
-  ! character(len=200) :: ext_str  ! this is used when multiple sets of yaml output is needed to cover different options (e.g., true and false)
   type(yaml_vars) :: yaml
   integer  :: unit_input, unit_output, y_nstep
-  integer,save :: n_calls=0   ! some subroutines are called multiple times in one timestep, record the number of calls
+
+  ! some subroutines are called multiple times in one timestep, record the number of calls
+  integer,save :: n_calls=0
+
 
   !populate YAML structure
-  yaml%lev_print = <Add hardwired level here> !level (**remove these if generating data for a dependent subroutines**)
-  yaml%nstep_print = <add hardwired time step here> !time step(**remove these if generating data for a dependent subroutines**)
+  !(**remove yaml%lev_print, nstep_print, col_print if generating data for a dependent subroutines**)
+  yaml%lev_print = <Add hardwired level here>       !level
+  yaml%nstep_print = <add hardwired time step here> !time step
 
-  ! set ext_str if there are multiple sets of yaml output to be write out
-  ! here gives an example that "flag" in the code can be 0, 1, or 2:
-  ! write(ext_str,'(I2)') flag
-  ! ext_str = 'flag_'//adjustl(ext_str)
+  yaml%col_print = icolprnt(y_lchnk)                !column to write data
 
+  !current_time step
+  y_nstep = get_nstep()
 
-  !YAML file input generation code- DO NOT PORT to C++
-  !print all inputs one-by-one at column "yaml%col_print"
-  yaml%col_print = icolprnt(y_lchnk) !column to write data(**remove these if generating data for a dependent subroutines**)
-  y_nstep = get_nstep() !time step (**remove these if generating data for a dependent subroutines**)
+  !Flag to decide to write or not to write data
+  yaml%flag_print = .false. !(**remove these if generating data for a dependent subroutines**)
 
-  yaml%flag_print = .false. ! to write or not to write data (**remove these if generating data for a dependent subroutines**)
   if(yaml%col_print == y_i .and. y_nstep==yaml%nstep_print .and. y_k == yaml%lev_print) then ! if this column exists in y_lchnk
-     !<
-     !In the case of y_i or y_k are not passed as arguments:
+
+     !-----------------------------------------------------------------------------------------
+     !In the case of y_i or y_k are not passed as arguments, use the following if condition:
      !if(yaml%col_print >0 .and. y_nstep==yaml%nstep_print) then
+     !-----------------------------------------------------------------------------------------
 
-     !For generating data for a dependent subroutines where "yaml" derived type is already initialized:
+     !-----------------------------------------------------------------------------------------
+     !For generating data for a dependent subroutines where "yaml" derived type is already
+     !initialized, use the following if condition
      !if(yaml%flag_print) then
-     !>
+     !-----------------------------------------------------------------------------------------
 
-     ! record number of calls that can output yaml file. you only need to write one set of input/output
+     !-----------------------------------------------------------------------------------------
+     ! Set "ext_str" if there are multiple sets of yaml output to be written out
+     ! Example:"flag" in the code can be 0, 1, or 2, we can update "ext_str" as:
+     ! write(ext_str,'(I2)') flag
+     ! ext_str = 'flag_'//adjustl(ext_str)
+     !-----------------------------------------------------------------------------------------
+
+
+     !Record number of calls that can output yaml file if you only need to write one set of input/output
      n_calls = n_calls+1
-     if (n_calls==1) then ! output the first call. change this if writing out other calls
-     ! if ((n_calls==1 .and. flag==0) .or. (n_calls==3 .and. flag==1) .or. (n_calls==5 .and. flag==2)) then ! this is an example of writing multiple sets of YAML files
 
-        yaml%lchnk_print = y_lchnk !(**remove these if generating data for a dependent subroutines**)
-        yaml%flag_print  = .true.!(**remove these if generating data for a dependent subroutines**)
+     if (n_calls==1) then ! output at the first call only, modify this if condition (see below) if writing out other calls
 
-        !open I/O yaml files (it can have an extra optional argument to pass a unique string to differentiate file names)
+        !if ((n_calls==1 .and. flag==0) .or. (n_calls==3 .and. flag==1) .or. (n_calls==5 .and. flag==2)) then
+
+        !(**remove these yaml% variables if generating data for a dependent subroutines**)
+        yaml%lchnk_print = y_lchnk
+        yaml%flag_print  = .true.
+
+
+        !open I/O yaml files
+        !(with an optional argument to pass a unique string to differentiate file names)
         call open_files(SUB_NAME, &  !intent-in
              unit_input, unit_output) !intent-out
-!             unit_input, unit_output, trim(ext_str)) !intent-out, with the use of ext_str
+        !    unit_input, unit_output, trim(ext_str)) !intent-out, with the use of ext_str
 
 
         !start by adding an input string
         call write_input_output_header(unit_input, unit_output,yaml%lchnk_print,yaml%col_print, &
              SUB_NAME,yaml%nstep_print, yaml%lev_print)
 
-        !< add code for writing data here>
-        !call write_var(unit_input, unit_output, fld_name,field)!write a single variable
-        !call write_1d_var(unit_input, unit_output, fld_name,dim,field) ! writes 1D variables of any dimension
-        !call write_2d_var(unit_input, unit_output, fld_name, dim1, dim2, field) ! writes 2D variables of any dimension: field(dim1,dim2)
+        ! add code for writing data here
+        WRITE_CALLS
+
 
         !writes aerosol mmr from state%q or q vector (cloud borne and interstitial)
         !"aer_num_only" is .ture. if printing aerosol num only

--- a/mam4_refactor_scripts/end.inp
+++ b/mam4_refactor_scripts/end.inp
@@ -1,15 +1,11 @@
 !#ifdef YAML_CPP
-  ! YAML file output generation code- DO NOT PORT to C++
   if(yaml%flag_print) then ! if this column exists in lchnk
 
      !write output header
      call write_output_header(unit_output)
 
      !start writing data
-     !<add code for writing data here>
-     !call write_output_var(unit_output, fld_name, field, inp_out_str)  !write a single output variable
-     !call write_1d_output_var(unit_output, fld_name, dim, field, inp_out_str) !writes 1D variables of any dimension in the output python module
-     !call write_2d_output_var(unit_output, fld_name, dim1, dim2, field, inp_out_str) !writes 2D variables of any dimension in the output python module
+     WRITE_CALLS
 
      !writes aerosol mmr from state%q or q vector(cloud borne and interstitial) in the output python module
      !"aer_num_only" is .ture. if printing aerosol num only
@@ -20,7 +16,8 @@
      call freeunit(unit_output)
   endif
 
-! this part of the code is for finding the best lat/lon and n_calls.
+!------------------------------------------------------------------------------------------------------------------------------
+! This part of the code is for finding the best lat/lon and n_calls.
 
 ! find lag/lon/y_nstep/y_k
 !if(masterproc .and. some condition) then
@@ -29,10 +26,11 @@
 !endif
 
 ! find n_calls. the if statement below should be consistent with the if condition in the *_beg_yml.f90 file
-! so that the corresponding n_calls are printed out here. 
-! Note that n_calls may change when lat/lon/y_nstep/y_k change 
+! so that the corresponding n_calls are printed out here.
+! Note that n_calls may change when lat/lon/y_nstep/y_k change
 !if(yaml%col_print == y_i .and. y_nstep==yaml%nstep_print .and. y_k == yaml%lev_print) then
 !      write(103,*) 'n_calls = ',n_calls, <any of the input/output variables to choose n_calls>
 !endif
-     
+!------------------------------------------------------------------------------------------------------------------------------
+
 #endif

--- a/mam4_refactor_scripts/gen_input_write_vars.py
+++ b/mam4_refactor_scripts/gen_input_write_vars.py
@@ -1,0 +1,66 @@
+#!/bin/python
+import argparse
+
+#-------------------------------------------------------------------
+# Purpose: Given a list of intent-ins, inouts and outs, this script
+# --------
+#         print calls for writing variables for the yaml/python I/O
+#         generation code
+#-------------------------------------------------------------------
+
+def main():
+
+    #parse command line arguments
+    ins,outs,finp,fout = parse_args()
+
+    #Break the inputs string into individual variables and remove white spaces
+    in_vars = [el.strip() for el in ins.split(',')]
+    out_vars = [el.strip() for el in outs.split(',')]
+
+
+
+    #Generate write line fortran codes
+    #input calls
+    write_calls(in_vars, finp)
+
+    #output calls
+    write_calls(out_vars, fout, False)
+
+# Rest of the functions
+
+def write_calls(var_list, fname, is_input=True):
+
+    #if the calls are for writing input YAML files,
+    # we need both the input and output units as
+    #input is also written to the python files
+    #Note: commas are the part of these strings
+    if is_input:
+        unit1 = 'unit_input,'
+        unit2 = 'unit_output,'
+    #if the calls are for writing output Python files,
+    # we need just the output unit as
+    #output is only written to the python file
+    else:
+        unit1 = 'unit_output,'
+        unit2 = ''
+
+    #loop through variables and write code for the calls
+    with open(fname,'w') as fw:
+        for var in var_list:
+            fw.write(f"        call write_var({unit1}{unit2}'{var}',{var})\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-i', type=str, help="A comma separated list of intent-in/inout variables", required=True)
+    parser.add_argument('-o', type=str, help="A comma separated list of intent-out/inout variables", required=True)
+    parser.add_argument('--finp', type=str, help="File name for in calls", required=True)
+    parser.add_argument('--fout', type=str, help="File name for out calls", required=True)
+
+    args = parser.parse_args()
+
+    #return the args captured by -i and -o flags
+    return args.i, args.o, args.finp, args.fout
+
+
+main()

--- a/mam4_refactor_scripts/test_gen_for_sub.sh
+++ b/mam4_refactor_scripts/test_gen_for_sub.sh
@@ -112,13 +112,12 @@ create_code_for_in_outs () {
 
 create_file () {
 
-    #create_file $module_name $sub_name $yaml_dir_path $relative_path "end"
+    #create_file $module_name $sub_name $yaml_dir_path $relative_path $ftmp_ins/$ftmp_outs "beginning"/"end"
     echo "(Add the following line at the $6 of the subroutine)"
 
     #find beginning or end sub string
     if [ $6 == "beginning" ]; then
         sub_str=beg
-        fwcode = 
     elif [ $6 == "end" ]; then
         sub_str=end
     else

--- a/mam4_refactor_scripts/test_gen_for_sub.sh
+++ b/mam4_refactor_scripts/test_gen_for_sub.sh
@@ -7,16 +7,24 @@ main() {
     #-------------------------
 
     #subroutine name
-    sub_name=calc_1_impact_rate
+    sub_name=hetfrz_classnuc_calc
+
+    #ins and in-outs variables
+    #(a comma seprated string, like 'var1, var2, var3'- remember the quotes around the list of variables)
+    ins='deltat, temperature, pressure, supersatice, fn, r3lx, icnlx, hetraer, awcam, awfacm, dstcoat, total_aer_num, coated_aer_num, uncoated_aer_num, total_interstitial_aer_num, total_cloudborne_aer_num'
+
+    #outs and in-outs variables
+    #(a comma seprated string, same as above)
+    outs='frzbcimm, frzduimm, frzbccnt, frzducnt, frzbcdep, frzdudep, errstring'
 
     #module name
-    module_name=aero_model
+    module_name=hetfrz_classnuc
 
     #file path
-    dir_path=components/eam/src/chemistry/modal_aero/
+    dir_path=components/eam/src/physics/cam/
 
     #CPP directive to turn on file writing
-    cpp_directive=YAML_AERO_MODEL
+    cpp_directive=YAML_HETFRZ_CLASSNUC
 
     #-------------------------
     #USER INPUT ENDS
@@ -24,7 +32,6 @@ main() {
 
     #----------------------------------------------------------------------------------------------------
     #----------------------------------------------------------------------------------------------------
-
 
     #ensure that script is run in the right directory (i.e. "e3sm_mam4_refactor") as
     #relative path code works only if script is run at the code root
@@ -41,29 +48,36 @@ main() {
     #path to directory containing beg and end input stubs
     stub_dir=mam4_refactor_scripts
 
-
-
     #relative path
     relative_path=`realpath --relative-to="$dir_path" "$yaml_dir_path"`
 
     #create directory and files if not already created
     /bin/mkdir -p $yaml_dir_path/$module_name/f90_yaml
 
+    #generate code in tmp files for the calls to add in the "beg" and "end" files
+    ftmp_ins='tmp_in_calls.txt'
+    ftmp_outs='tmp_out_calls.txt'
+    create_code_for_in_outs "$ins" "$outs" $ftmp_ins $ftmp_outs
+
     #code to add
-    echo '-------------'
-    echo 'Code to add:'
-    echo '-------------'
+    echo '----------------------------'
+    echo 'Code to add to the F90 file:'
+    echo '----------------------------'
 
     echo '(If not already added, add the following line at module level at the top)'
     echo "#include \"$relative_path/common_files/common_uses.ymlf90\""
 
+
     #Subroutine beginning file
     newline
-    create_file $module_name $sub_name $yaml_dir_path $relative_path "beginning"
+    create_file $module_name $sub_name $yaml_dir_path $relative_path $ftmp_ins "beginning"
 
     #subroutine end file
     newline
-    create_file $module_name $sub_name $yaml_dir_path $relative_path "end"
+    create_file $module_name $sub_name $yaml_dir_path $relative_path $ftmp_outs "end"
+
+    #remove temporary files
+    rm $ftmp_ins $ftmp_outs
 }
 
 #---------------------
@@ -73,15 +87,39 @@ main() {
 #Generate a newline
 newline () { echo ''; }
 
+create_code_for_in_outs () {
+    newline
+    newline
+    echo 'Generating files with code to add to the include files ......'
+    newline
+    #call python script to generate code for the calls
+    MY_PATH="$(dirname -- "${BASH_SOURCE[0]}")" # relative path
+    MY_PATH="$(cd -- "$MY_PATH" && pwd)"        # absolute and normalized path
+    /bin/python3 $MY_PATH/gen_input_write_vars.py  --finp $3 --fout $4 -i "$1" -o "$2"
+
+    #check if the files exists that has intent-in, intent-inouts and intent-outs calls
+    if [ ! -f $3 ]; then
+        echo "File tmp_in_calls.txt doesn't exist, check gen_input_write_vars.py script, exiting"
+        exit 1
+    fi
+    if [ ! -f $4 ]; then
+        echo "File tmp_out_calls.txt doesn't exist, check gen_input_write_vars.py script, exiting"
+        exit 1
+    fi
+
+}
+
+
 create_file () {
 
     #create_file $module_name $sub_name $yaml_dir_path $relative_path "end"
-    echo "(Add the following line at the $5 of the subroutine)"
+    echo "(Add the following line at the $6 of the subroutine)"
 
     #find beginning or end sub string
-    if [ $5 == "beginning" ]; then
+    if [ $6 == "beginning" ]; then
         sub_str=beg
-    elif [ $5 == "end" ]; then
+        fwcode = 
+    elif [ $6 == "end" ]; then
         sub_str=end
     else
         echo 'Invalid string (beginning or end)for function create_file'
@@ -105,6 +143,7 @@ create_file () {
         f_tmp=tmp.inp
         sed s/"!#ifdef YAML_CPP"/"#ifdef $cpp_directive"/g $stub_dir/${sub_str}.inp > $f_tmp
         sed -i s/"SUB_NAME"/"\'$2\'"/g $f_tmp
+        sed -i -e "/WRITE_CALLS/r $5" -e "s///" $f_tmp
         cat $f_tmp>>$f_path
         /bin/rm $f_tmp
     fi


### PR DESCRIPTION
Unified write_var calls so that we have the same call signature for all variables irrespective of their dimensions (1D, 2D, etc.). The process of creating test files for each subroutine is now automated where the calls for writing intent/in/outs variables are pre-populated in the files capturing input and outputs.

A major YAML I/O F90 file reorg where new unified call signatures are introduced while maintaining backward compatibility.