### PR TITLE
Refactor subroutines for seasalt emission

### DIFF
--- a/components/eam/src/chemistry/aerosol/sslt_sections.F90
+++ b/components/eam/src/chemistry/aerosol/sslt_sections.F90
@@ -38,7 +38,14 @@ module sslt_sections
        1.1668e-5_r8, 1.4786e-5_r8, 1.8736e-5_r8,  &
        2.3742e-5_r8 /)
 
-  real(r8), dimension(nsections) :: bm, rdry, rm
+  ! use Ekmam's ss
+  real(r8),parameter :: rdry(1:nsections)=Dg(1:nsections)/2._r8          ! radius [m]
+
+  ! multiply rm with 1.814 because it should be RH=80% and not dry particles
+  ! for the parameterization
+  real(r8),parameter :: rm(1:nsections)=1.814_r8*rdry(1:nsections)*1.e6_r8   ! um
+  real(r8),parameter :: bm(1:nsections)=(0.380_r8-log10(rm(1:nsections)))/0.65_r8  ! use in Manahan
+
   real(r8), dimension(4,nsections) :: consta, constb  !constants for calculating emission polynomial
 
 contains
@@ -47,48 +54,62 @@ contains
   !===========================================================================
   subroutine sslt_sections_init()
 
-    integer :: m
+    integer :: isec
 
     ! use Ekman's ss
-    rdry(:)=Dg(:)/2._r8   ! meter
+   
     ! multiply rm with 1.814 because it should be RH=80% and not dry particles
     ! for the parameterization
-    rm(:)=1.814_r8*rdry(:)*1.e6_r8   ! um
-    bm(:)=(0.380_r8-log10(rm(:)))/0.65_r8  ! use in Manahan
+   
 
     ! calculate constants form emission polynomials
-    do m = sec1_beg, sec1_end
-       consta(1,m) = (-2.576_r8)*10._r8**35*Dg(m)**4+5.932_r8*10._r8**28  &
-               * Dg(m)**3+(-2.867_r8)*10._r8**21*Dg(m)**2+(-3.003_r8)  &
-               * 10._r8**13*Dg(m) + (-2.881_r8)*10._r8**6
-       constb(1,m) = 7.188_r8*10._r8**37  &
-               * Dg(m)**4+(-1.616_r8)*10._r8**31*Dg(m)**3+6.791_r8*10._r8**23  &
-               * Dg(m)**2+1.829_r8*10._r8**16*Dg(m)+7.609_r8*10._r8**8
+    do isec = sec1_beg, sec1_end
+       consta(1,isec) = (-2.576_r8)*10._r8**35 * Dg(isec)**4 + &
+                           5.932_r8*10._r8**28 * Dg(isec)**3 + &
+                        (-2.867_r8)*10._r8**21 * Dg(isec)**2 + &
+                        (-3.003_r8)*10._r8**13 * Dg(isec) + &
+                        (-2.881_r8)*10._r8**6
+
+       constb(1,isec) = 7.188_r8*10._r8**37 * Dg(isec)**4 + &
+                     (-1.616_r8)*10._r8**31 * Dg(isec)**3 + &
+                        6.791_r8*10._r8**23 * Dg(isec)**2 + &
+                        1.829_r8*10._r8**16 * Dg(isec) + &
+                        7.609_r8*10._r8**8
     enddo
 
-    do m = sec2_beg, sec2_end
-       consta(2,m) = (-2.452_r8)*10._r8**33*Dg(m)**4+2.404_r8*10._r8**27  &
-               * Dg(m)**3+(-8.148_r8)*10._r8**20*Dg(m)**2+(1.183_r8)*10._r8**14 &
-               * Dg(m)+(-6.743_r8)*10._r8**6
-       constb(2,m) = 7.368_r8*10._r8**35  &
-               * Dg(m)**4+(-7.310_r8)*10._r8**29*Dg(m)**3+ 2.528_r8*10._r8**23 &
-               * Dg(m)**2+(-3.787_r8)*10._r8**16*Dg(m)+ 2.279_r8*10._r8**9
+    do isec = sec2_beg, sec2_end
+       consta(2,isec) = (-2.452_r8)*10._r8**33 * Dg(isec)**4 + &
+                           2.404_r8*10._r8**27 * Dg(isec)**3 + &
+                        (-8.148_r8)*10._r8**20 * Dg(isec)**2 + &
+                         (1.183_r8)*10._r8**14 * Dg(isec) + &
+                        (-6.743_r8)*10._r8**6
+
+       constb(2,isec) = 7.368_r8*10._r8**35 * Dg(isec)**4 + &
+                     (-7.310_r8)*10._r8**29 * Dg(isec)**3 + &
+                        2.528_r8*10._r8**23 * Dg(isec)**2 + &
+                     (-3.787_r8)*10._r8**16 * Dg(isec)+ &
+                        2.279_r8*10._r8**9
     enddo
 
-    do m = sec3_beg, sec3_end
-       consta(3,m) = (1.085_r8)*10._r8**29*Dg(m)**4+(-9.841_r8)*10._r8**23  &
-               * Dg(m)**3+(3.132_r8)*10._r8**18*Dg(m)**2+(-4.165_r8)*10._r8**12 &
-               * Dg(m)+(2.181_r8)*10._r8**6
-       constb(3,m) = (-2.859_r8)*10._r8**31  &
-               * Dg(m)**4+(2.601_r8)*10._r8**26*Dg(m)**3+(-8.297_r8)*10._r8**20 &
-               * Dg(m)**2+(1.105_r8)*10._r8**15*Dg(m)+(-5.800_r8)*10._r8**8
+    do isec = sec3_beg, sec3_end
+       consta(3,isec) = (1.085_r8)*10._r8**29 * Dg(isec)**4 + &
+                       (-9.841_r8)*10._r8**23 * Dg(isec)**3 + &
+                        (3.132_r8)*10._r8**18 * Dg(isec)**2 + &
+                       (-4.165_r8)*10._r8**12 * Dg(isec) + &
+                        (2.181_r8)*10._r8**6
+
+       constb(3,isec) = (-2.859_r8)*10._r8**31 * Dg(isec)**4 + &
+                         (2.601_r8)*10._r8**26 * Dg(isec)**3 + &
+                        (-8.297_r8)*10._r8**20 * Dg(isec)**2 + &
+                         (1.105_r8)*10._r8**15 * Dg(isec) + &
+                        (-5.800_r8)*10._r8**8
     enddo
 
-    do m = sec4_beg, sec4_end
+    do isec = sec4_beg, sec4_end
        ! use monahan
-          consta(4,m) = (1.373_r8*rm(m)**(-3)*(1+0.057_r8*rm(m)**1.05_r8)  &
-               * 10**(1.19_r8*exp(-bm(m)**2)))  &
-               * (rm(m)-rm(m-1))
+          consta(4,isec) = (1.373_r8*rm(isec)**(-3)*(1+0.057_r8*rm(isec)**1.05_r8)  &
+                          * 10**(1.19_r8*exp(-bm(isec)**2)))  &
+                          * (rm(isec)-rm(isec-1))
     enddo
 
   end subroutine sslt_sections_init
@@ -103,32 +124,32 @@ contains
 
     real (r8) :: fi(ncol,nsections)
 
-    integer :: m
-    real (r8) :: W(ncol)
+    integer :: isec
+    real (r8) :: warea(ncol)
 
     ! Calculations of source strength and size distribution
     ! NB the 0.1 is the dlogDp we have to multiplie with to get the flux, but the value dependence
     ! of course on what dlogDp you have. You will also have to change the sections of Dg if you use
     ! a different number of size bins with different intervals.
 
-    W(:ncol)=3.84e-6_r8*u10cubed(:ncol)*0.1_r8 ! whitecap area
+    warea(:ncol)=3.84e-6_r8*u10cubed(:ncol)*0.1_r8 ! whitecap area
 
     ! calculate number flux fi (#/m2/s)
     fi(:,:)=0._r8
-    do m = sec1_beg, sec1_end
-       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(1,m)+constb(1,m))
+    do isec = sec1_beg, sec1_end
+       fi(:ncol,isec)=warea(:ncol)*((sst(:ncol))*consta(1,isec)+constb(1,isec))
     enddo
 
-    do m = sec2_beg, sec2_end
-       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(2,m)+constb(2,m))
+    do isec = sec2_beg, sec2_end
+       fi(:ncol,isec)=warea(:ncol)*((sst(:ncol))*consta(2,isec)+constb(2,isec))
     enddo
 
-    do m = sec3_beg, sec3_end
-       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(3,m)+constb(3,m))
+    do isec = sec3_beg, sec3_end
+       fi(:ncol,isec)=warea(:ncol)*((sst(:ncol))*consta(3,isec)+constb(3,isec))
     enddo
 
-    do m = sec4_beg, sec4_end
-       fi(:ncol,m)=consta(4,m)*u10cubed(:ncol)
+    do isec = sec4_beg, sec4_end
+       fi(:ncol,isec)=consta(4,isec)*u10cubed(:ncol)
     enddo
 
   end function fluxes

--- a/components/eam/src/chemistry/aerosol/sslt_sections.F90
+++ b/components/eam/src/chemistry/aerosol/sslt_sections.F90
@@ -14,7 +14,15 @@ module sslt_sections
   public :: Dg
   public :: rdry
 
-  integer,parameter :: nsections = 31
+  integer, parameter :: nsections = 31
+  integer, parameter :: sec1_beg = 1
+  integer, parameter :: sec1_end = 9
+  integer, parameter :: sec2_beg = 10
+  integer, parameter :: sec2_end = 13
+  integer, parameter :: sec3_beg = 14
+  integer, parameter :: sec3_end = 21
+  integer, parameter :: sec4_beg = 22
+  integer, parameter :: sec4_end = nsections
 
   ! only use up to ~20um
   real(r8),parameter :: Dg(nsections) = (/  &
@@ -49,7 +57,7 @@ contains
     bm(:)=(0.380_r8-log10(rm(:)))/0.65_r8  ! use in Manahan
 
     ! calculate constants form emission polynomials
-    do m = 1, 9
+    do m = sec1_beg, sec1_end
        consta(1,m) = (-2.576_r8)*10._r8**35*Dg(m)**4+5.932_r8*10._r8**28  &
                * Dg(m)**3+(-2.867_r8)*10._r8**21*Dg(m)**2+(-3.003_r8)  &
                * 10._r8**13*Dg(m) + (-2.881_r8)*10._r8**6
@@ -58,7 +66,7 @@ contains
                * Dg(m)**2+1.829_r8*10._r8**16*Dg(m)+7.609_r8*10._r8**8
     enddo
 
-    do m = 10, 13
+    do m = sec2_beg, sec2_end
        consta(2,m) = (-2.452_r8)*10._r8**33*Dg(m)**4+2.404_r8*10._r8**27  &
                * Dg(m)**3+(-8.148_r8)*10._r8**20*Dg(m)**2+(1.183_r8)*10._r8**14 &
                * Dg(m)+(-6.743_r8)*10._r8**6
@@ -67,7 +75,7 @@ contains
                * Dg(m)**2+(-3.787_r8)*10._r8**16*Dg(m)+ 2.279_r8*10._r8**9
     enddo
 
-    do m = 14, 21
+    do m = sec3_beg, sec3_end
        consta(3,m) = (1.085_r8)*10._r8**29*Dg(m)**4+(-9.841_r8)*10._r8**23  &
                * Dg(m)**3+(3.132_r8)*10._r8**18*Dg(m)**2+(-4.165_r8)*10._r8**12 &
                * Dg(m)+(2.181_r8)*10._r8**6
@@ -76,7 +84,7 @@ contains
                * Dg(m)**2+(1.105_r8)*10._r8**15*Dg(m)+(-5.800_r8)*10._r8**8
     enddo
 
-    do m = 22, nsections
+    do m = sec4_beg, sec4_end
        ! use monahan
           consta(4,m) = (1.373_r8*rm(m)**(-3)*(1+0.057_r8*rm(m)**1.05_r8)  &
                * 10**(1.19_r8*exp(-bm(m)**2)))  &
@@ -107,19 +115,19 @@ contains
 
     ! calculate number flux fi (#/m2/s)
     fi(:,:)=0._r8
-    do m=1, 9
+    do m = sec1_beg, sec1_end
        fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(1,m)+constb(1,m))
     enddo
 
-    do m=10, 13
+    do m = sec2_beg, sec2_end
        fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(2,m)+constb(2,m))
     enddo
 
-    do m=14, 21
+    do m = sec3_beg, sec3_end
        fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(3,m)+constb(3,m))
     enddo
 
-    do m=22, nsections
+    do m = sec4_beg, sec4_end
        fi(:ncol,m)=consta(4,m)*u10cubed(:ncol)
     enddo
 

--- a/components/eam/src/chemistry/aerosol/sslt_sections.F90
+++ b/components/eam/src/chemistry/aerosol/sslt_sections.F90
@@ -49,35 +49,40 @@ contains
     bm(:)=(0.380_r8-log10(rm(:)))/0.65_r8  ! use in Manahan
 
     ! calculate constants form emission polynomials
-    do m=1,nsections
-       if ((m).le.9)then
-          consta(1,m) = (-2.576_r8)*10._r8**35*Dg(m)**4+5.932_r8*10._r8**28  &
+    do m = 1, 9
+       consta(1,m) = (-2.576_r8)*10._r8**35*Dg(m)**4+5.932_r8*10._r8**28  &
                * Dg(m)**3+(-2.867_r8)*10._r8**21*Dg(m)**2+(-3.003_r8)  &
                * 10._r8**13*Dg(m) + (-2.881_r8)*10._r8**6
-          constb(1,m) = 7.188_r8*10._r8**37  &
+       constb(1,m) = 7.188_r8*10._r8**37  &
                * Dg(m)**4+(-1.616_r8)*10._r8**31*Dg(m)**3+6.791_r8*10._r8**23  &
                * Dg(m)**2+1.829_r8*10._r8**16*Dg(m)+7.609_r8*10._r8**8
-       elseif ((m).ge.10.and.(m).le.13)then
-          consta(2,m) = (-2.452_r8)*10._r8**33*Dg(m)**4+2.404_r8*10._r8**27  &
-               * Dg(m)**3+(-8.148_r8)*10._r8**20*Dg(m)**2+(1.183_r8)*10._r8**14  &
+    enddo
+
+    do m = 10, 13
+       consta(2,m) = (-2.452_r8)*10._r8**33*Dg(m)**4+2.404_r8*10._r8**27  &
+               * Dg(m)**3+(-8.148_r8)*10._r8**20*Dg(m)**2+(1.183_r8)*10._r8**14 &
                * Dg(m)+(-6.743_r8)*10._r8**6
-          constb(2,m) = 7.368_r8*10._r8**35  &
-               * Dg(m)**4+(-7.310_r8)*10._r8**29*Dg(m)**3+ 2.528_r8*10._r8**23  &
+       constb(2,m) = 7.368_r8*10._r8**35  &
+               * Dg(m)**4+(-7.310_r8)*10._r8**29*Dg(m)**3+ 2.528_r8*10._r8**23 &
                * Dg(m)**2+(-3.787_r8)*10._r8**16*Dg(m)+ 2.279_r8*10._r8**9
-       elseif ((m).ge.14.and.(m).lt.22)then
-          consta(3,m) = (1.085_r8)*10._r8**29*Dg(m)**4+(-9.841_r8)*10._r8**23  &
-               * Dg(m)**3+(3.132_r8)*10._r8**18*Dg(m)**2+(-4.165_r8)*10._r8**12  &
+    enddo
+
+    do m = 14, 21
+       consta(3,m) = (1.085_r8)*10._r8**29*Dg(m)**4+(-9.841_r8)*10._r8**23  &
+               * Dg(m)**3+(3.132_r8)*10._r8**18*Dg(m)**2+(-4.165_r8)*10._r8**12 &
                * Dg(m)+(2.181_r8)*10._r8**6
-          constb(3,m) = (-2.859_r8)*10._r8**31  &
-               * Dg(m)**4+(2.601_r8)*10._r8**26*Dg(m)**3+(-8.297_r8)*10._r8**20  &
+       constb(3,m) = (-2.859_r8)*10._r8**31  &
+               * Dg(m)**4+(2.601_r8)*10._r8**26*Dg(m)**3+(-8.297_r8)*10._r8**20 &
                * Dg(m)**2+(1.105_r8)*10._r8**15*Dg(m)+(-5.800_r8)*10._r8**8
-       elseif (m.ge.22.and.m.le.40)then
-          ! use monahan
+    enddo
+
+    do m = 22, nsections
+       ! use monahan
           consta(4,m) = (1.373_r8*rm(m)**(-3)*(1+0.057_r8*rm(m)**1.05_r8)  &
                * 10**(1.19_r8*exp(-bm(m)**2)))  &
                * (rm(m)-rm(m-1))
-       endif
     enddo
+
   end subroutine sslt_sections_init
 
   !===========================================================================
@@ -102,17 +107,20 @@ contains
 
     ! calculate number flux fi (#/m2/s)
     fi(:,:)=0._r8
-    do m=1,nsections
-       if (m.le.9)then
-          fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(1,m)+constb(1,m))
-       elseif (m.ge.10.and.m.le.13)then
-          fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(2,m)+constb(2,m))
-       elseif (m.ge.14.and.m.lt.22)then
-          fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(3,m)+constb(3,m))
-       elseif (m.ge.22.and.m.le.40)then
-          ! use Monahan
-          fi(:ncol,m)=consta(4,m)*u10cubed(:ncol)
-       endif
+    do m=1, 9
+       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(1,m)+constb(1,m))
+    enddo
+
+    do m=10, 13
+       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(2,m)+constb(2,m))
+    enddo
+
+    do m=14, 21
+       fi(:ncol,m)=W(:ncol)*((sst(:ncol))*consta(3,m)+constb(3,m))
+    enddo
+
+    do m=22, nsections
+       fi(:ncol,m)=consta(4,m)*u10cubed(:ncol)
     enddo
 
   end function fluxes

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1541,7 +1541,7 @@ lphase_jnmw_conditional: &
   !=============================================================================
   !=============================================================================
   subroutine aero_model_emissions( state, cam_in )
-    use seasalt_model, only: seasalt_emis, seasalt_names, seasalt_indices, seasalt_active,seasalt_nbin, &
+    use seasalt_model, only: seasalt_emis, marine_organic_emis, seasalt_names, seasalt_indices, seasalt_active,seasalt_nbin, &
          has_mam_mom, nslt_om
     use dust_model,    only: dust_emis, dust_names, dust_indices, dust_active,dust_nbin, dust_nnum
 
@@ -1593,7 +1593,9 @@ lphase_jnmw_conditional: &
        sflx(:)=0._r8
        F_eff(:)=0._r8
 
-       call seasalt_emis(u10, u10cubed, lchnk, cam_in%sst, cam_in%ocnfrac, ncol, cam_in%cflx, seasalt_emis_scale, F_eff)
+       call seasalt_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, cam_in%cflx)
+
+       call marine_organic_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, cam_in%cflx, F_eff)
 
        ! Write out salt mass fluxes to history files
        do m=1,seasalt_nbin-nslt_om

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1593,9 +1593,11 @@ lphase_jnmw_conditional: &
        sflx(:)=0._r8
        F_eff(:)=0._r8
 
-       call seasalt_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, cam_in%cflx)
+       call seasalt_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, &  ! in 
+                         cam_in%cflx)                                                              ! inout
 
-       call marine_organic_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, cam_in%cflx, F_eff)
+       call marine_organic_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, & ! in
+                                cam_in%cflx)                                                             ! inout
 
        ! Write out salt mass fluxes to history files
        do m=1,seasalt_nbin-nslt_om
@@ -1607,17 +1609,16 @@ lphase_jnmw_conditional: &
        call outfld('SSTSFMBL',sflx(:),pcols,lchnk)
 
        ! Write out marine organic mass fluxes to history files
-       if ( has_mam_mom ) then
-          sflx(:)=0._r8
-          do m=seasalt_nbin-nslt_om+1,seasalt_nbin
-             mm = seasalt_indices(m)
-             sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
-             call outfld(trim(seasalt_names(m))//'SF',cam_in%cflx(:,mm),pcols,lchnk)
-          enddo
-          ! accumulated flux
-          call outfld('SSTSFMBL_OM',sflx(:),pcols,lchnk)
+        sflx(:)=0._r8
+        do m=seasalt_nbin-nslt_om+1,seasalt_nbin
+           mm = seasalt_indices(m)
+           sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
+           call outfld(trim(seasalt_names(m))//'SF',cam_in%cflx(:,mm),pcols,lchnk)
+        enddo
+        
+        ! accumulated flux
+        call outfld('SSTSFMBL_OM',sflx(:),pcols,lchnk)
 
-       endif
 
     endif
 

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1558,7 +1558,6 @@ lphase_jnmw_conditional: &
     real(r8) :: sflx(pcols)   ! accumulate over all bins for output
     real(r8) :: u10cubed(pcols)
     real(r8) :: u10(pcols)               ! Needed in Gantt et al. calculation of organic mass fraction
-    real(r8) :: F_eff(pcols) ! optional diagnostic output -- organic enrichment ratio
 
     real (r8), parameter :: z0=0.0001_r8  ! m roughness length over oceans--from ocean model
 
@@ -1591,7 +1590,6 @@ lphase_jnmw_conditional: &
        u10cubed(:ncol)=u10cubed(:ncol)**3.41_r8
 
        sflx(:)=0._r8
-       F_eff(:)=0._r8
 
        call seasalt_emis(lchnk, ncol, u10cubed, cam_in%sst, cam_in%ocnfrac, seasalt_emis_scale, &  ! in 
                          cam_in%cflx)                                                              ! inout

--- a/components/eam/src/chemistry/modal_aero/seasalt_model.F90
+++ b/components/eam/src/chemistry/modal_aero/seasalt_model.F90
@@ -706,67 +706,6 @@ subroutine omfrac_accu_aitk(om_ssa_in, om_ssa)
 
 end subroutine omfrac_accu_aitk
 
-subroutine gantt_omfrac_size(om_ssa_max, om_ssa)
-
-   !----------------------------------------------------------------------- 
-   ! Purpose:
-   ! For a given value of om_ssa_max, compute the dependence of the organic
-   ! mass fraction on particle size, following Gantt et al. (2011).
-   !
-   ! OM_SSA (D_p,RH=80%) =             OM_SSA,max
-   !                       -------------------------------   + OM_SSA,min
-   !                       1 + 0.03 exp(6.18 * D_p(RH=80%))
-   !
-   ! Mace Head: OM_SSA,min=0.03, OM_SSA,max=0.82
-   !
-   ! Here, substitute calculated value for OM_SSA,max.
-   ! D_p is RH=80% diameter in micrometers
-   ! Dg is dry diameter in meters
-   ! rdry is dry radius in meters
-   ! rm is RH=80% radius in micrometers
-   !
-   ! Original paper uses RH=80% diameter, but inserting dry diameter gives
-   !  a better match to observations.  Is it possible that Gantt et al. did
-   !  not consider mass-weighting of the diameter within each bin, leading
-   !  to a bias?
-   !
-   ! Note: D_p(RH=80%):D_p(dry) is approx. 2:1 (Lewis and Schwartz, 2004, p. 54)
-   !
-   ! Note: It is a reasonable approximation to use average diameter of each section
-   !  to calculate fraction of both number and mass in that section.
-   ! Errors are on the order of a few percent.
-   !
-   ! Author:
-   ! Susannah Burrows, 2015
-   !----------------------------------------------------------------------- 
-   use sslt_sections, only: nsections, Dg
-   implicit none
-   !-----------------------------------------------------------------------
-   ! Arguments:
-   !
-   real(r8), intent(in)    :: om_ssa_max(:)
-   real(r8), intent(inout) :: om_ssa(:,:)
-   !
-   ! Local variables
-   !
-   real(r8), parameter :: om_ssa_min = 0.03
-   integer  :: m
-   !
-   !-----------------------------------------------------------------------
-
-
-   ! calculate OM fraction!
-   do m=1,nsections
-      ! update only in Aitken and accu. modes
-      if (Dg(m) >= sst_sz_range_lo(2) .and. Dg(m) < sst_sz_range_hi(1)) then
-         om_ssa(:, m) = om_ssa_max(:) / (1._r8 + 0.03_r8 * exp(6.18_r8 * Dg(m) * 1.e-6_r8)) &
-                      + om_ssa_min
-      else
-         om_ssa(:, m) = 0.0_r8 ! Set to zero for "fine sea salt" and "coarse sea salt" modes
-      endif
-   enddo
-    
-end subroutine gantt_omfrac_size
 
 !-------------------------------------------------------------------
 !! READ INPUT FILES, CREATE FIELDS, and horizontally interpolate ocean data

--- a/components/eam/src/chemistry/modal_aero/seasalt_model.F90
+++ b/components/eam/src/chemistry/modal_aero/seasalt_model.F90
@@ -585,8 +585,8 @@ subroutine calc_om_ssa_burrows(lchnk, ncol, mpoly_in, mprot_in, mlip_in, &
    real(r8), intent(in) :: mlip_in(ncol)          ! for Burrows et al. (2014) organic mass fraction
    !
    ! Output variables
-   real(r8), intent(inout) :: mass_frac_bub_section(:,:,:)
-   real(r8), intent(inout) :: om_ssa(:,:)
+   real(r8), intent(inout) :: mass_frac_bub_section(:,:,:)          ! mass fraction per organic class per size bin [unitless]
+   real(r8), intent(inout) :: om_ssa(:,:)                           ! mass fraction per size bin [unitless]
 
    !
    ! Local variables
@@ -664,20 +664,16 @@ subroutine calc_om_ssa_burrows(lchnk, ncol, mpoly_in, mprot_in, mlip_in, &
    mass_frac_bub_tot(:) = sum(mass_frac_bub, dim=2)
 
 
-   ! Effective mass enrichment ratio (for bulk OM) -- diagnostic variable
-   !
-   ! F_eff_mass = organic mass per area (film) [g m-2] / salt mass per area (film) [g m-2] *
-   !                 bulk salt concentration [g m-3] / bulk OM concentration [g m-3]
-
-
    ! Distribute mass fraction evenly into Aitken and accumulation modes
-   call omfrac_accu_aitk(mass_frac_bub_tot(:), om_ssa(:,:))
+   call omfrac_accu_aitk(mass_frac_bub_tot(:), & ! in
+                         om_ssa(:,:))            ! inout
 
    ! mass_frac_bub_section(pcols, n_org_max, nsections) -- org classes in dim 2, size nsections in dim 3
    mass_frac_bub_section(:, :, :)   = 0.0_r8
 
    do iorg = 1, n_org_burrows
-      call omfrac_accu_aitk(mass_frac_bub(:, iorg), mass_frac_bub_section(:, iorg, :))
+      call omfrac_accu_aitk(mass_frac_bub(:, iorg), & ! in
+                            mass_frac_bub_section(:, iorg, :)) ! inout
    enddo
 
 end subroutine calc_om_ssa_burrows
@@ -694,8 +690,8 @@ subroutine omfrac_accu_aitk(om_ssa_in, om_ssa)
    !-----------------------------------------------------------------------
    ! Arguments:
    !
-   real(r8), intent(in)    :: om_ssa_in(:)     ! fraction
-   real(r8), intent(inout) :: om_ssa(:,:)      ! 
+   real(r8), intent(in)    :: om_ssa_in(:)     ! mass fraction [unitless]
+   real(r8), intent(inout) :: om_ssa(:,:)      ! mass fraction for each size bin [unitless]
    !
    ! Local variables
    !

--- a/components/eam/src/chemistry/modal_aero/seasalt_model.F90
+++ b/components/eam/src/chemistry/modal_aero/seasalt_model.F90
@@ -343,8 +343,6 @@ subroutine ocean_data_readnl(nlfile)
    fmoa          = mam_mom_parameterization
 
 
-!   ! Turn on mam_mom aerosols if user has specified an input dataset.
-!   has_mam_mom = len_trim(filename) > 0
 
 end subroutine ocean_data_readnl
 
@@ -386,7 +384,7 @@ end subroutine seasalt_emis
 
 
 subroutine seasalt_emisflx_calc(ncol, fi, ocnfrc, emis_scale, flx_type, & ! in
-                                cflx)                                          ! inout
+                                cflx)                                     ! inout
    
     use sslt_sections, only: nsections, fluxes, Dg, rdry
     use mo_constants,  only: dns_aer_sst=>seasalt_density, pi
@@ -396,7 +394,7 @@ subroutine seasalt_emisflx_calc(ncol, fi, ocnfrc, emis_scale, flx_type, & ! in
     real(r8), intent(in) :: fi(pcols, nsections)        ! sea salt number fluxes in each size bin [#/m2/s]
     real(r8), intent(in) :: ocnfrc(pcols)               ! ocean fraction [unitless]
     real(r8), intent(in) :: emis_scale                  ! sea salt emission tuning factor [unitless]
-    integer, intent(in)  :: flx_type
+    integer, intent(in)  :: flx_type                    ! number ==0 or mass ==1 flux to be calculated
 
     ! output
     real(r8), intent(inout) :: cflx(:,:)      ! mass and number emission fluxes for aerosols [kg/m2/s or #/m2/s]
@@ -531,13 +529,13 @@ subroutine marine_organic_emis(lchnk, ncol, u10cubed, srf_temp, ocnfrc, emis_sca
 
     ! Total external mixture: emit only in modes 4, 5
    
-    call marine_organic_numflx_calc(ncol, fi, ocnfrc, emis_scale, &
-                                    om_ssa, emit_this_mode, &       
-                                    cflx)
+    call marine_organic_numflx_calc(ncol, fi, ocnfrc, emis_scale, &  ! in 
+                                    om_ssa, emit_this_mode, &        ! in
+                                    cflx)                            ! inout
 
     call marine_organic_massflx_calc(ncol, fi, ocnfrc, emis_scale, om_ssa, &  ! in
                                      mass_frac_bub_section, emit_this_mode, & ! in
-                                     cflx)
+                                     cflx)                                    ! inout
 
 end subroutine marine_organic_emis
 
@@ -550,11 +548,11 @@ subroutine marine_organic_numflx_calc(ncol, fi, ocnfrc, emis_scale, &  ! in
 
     ! input
     integer, intent(in)  :: ncol
-    real(r8), intent(in) :: fi(pcols, nsections)   ! sea salt number fluxes in each size bin [#/m2/s]    
-    real(r8), intent(in) :: ocnfrc(pcols)          ! ocean fraction [unitless] 
-    real(r8), intent(in) :: emis_scale             ! sea salt emission tuning factor [unitless]
-    real(r8), intent(in) :: om_ssa(pcols, nsections)
-    logical, intent(in)  :: emit_this_mode(om_num_modes)
+    real(r8), intent(in) :: fi(pcols, nsections)          ! sea salt number fluxes in each size bin [#/m2/s]    
+    real(r8), intent(in) :: ocnfrc(pcols)                 ! ocean fraction [unitless] 
+    real(r8), intent(in) :: emis_scale                    ! sea salt emission tuning factor [unitless]
+    real(r8), intent(in) :: om_ssa(pcols, nsections)      ! marine organic aerosol fraction per size bin [unitless]
+    logical, intent(in)  :: emit_this_mode(om_num_modes)  ! logical flags turn on/off marine organic emission in aerosol modes 
 
     ! output
     real(r8), intent(inout) :: cflx(:,:)       ! mass and number emission fluxes for aerosols [kg/m2/s or #/m2/s]
@@ -603,12 +601,12 @@ subroutine marine_organic_massflx_calc(ncol, fi, ocnfrc, emis_scale, om_ssa, &  
 
     ! input
     integer, intent(in)  :: ncol
-    real(r8), intent(in) :: fi(pcols, nsections)   ! sea salt number fluxes in each size bin [#/m2/s]
-    real(r8), intent(in) :: ocnfrc(pcols)          ! ocean fraction [unitless] 
-    real(r8), intent(in) :: emis_scale             ! sea salt emission tuning factor [unitless]
-    real(r8), intent(in) :: om_ssa(pcols, nsections)
-    real(r8), intent(in) :: mass_frac_bub_section(pcols, n_org_max, nsections)
-    logical, intent(in)  :: emit_this_mode(om_num_modes)
+    real(r8), intent(in) :: fi(pcols, nsections)             ! sea salt number fluxes in each size bin [#/m2/s]
+    real(r8), intent(in) :: ocnfrc(pcols)                    ! ocean fraction [unitless] 
+    real(r8), intent(in) :: emis_scale                       ! sea salt emission tuning factor [unitless]
+    real(r8), intent(in) :: om_ssa(pcols, nsections)         ! marine organic aerosol fraction per size bin [unitless]
+    real(r8), intent(in) :: mass_frac_bub_section(pcols, n_org_max, nsections) ! marine organic aerosol fraction per organic species per size bin [unitless]
+    logical, intent(in)  :: emit_this_mode(om_num_modes)     ! logical flags turn on/off marine organic emission in aerosol modes
 
     ! output
     real(r8), intent(inout) :: cflx(:,:)       ! mass and number emission fluxes for aerosols [kg/m2/s or #/m2/s]


### PR DESCRIPTION
Refactor subroutines in seasalt_model.F90 and sslt_sections.F90 for seasalt emission.

break the seasalt_emis to two parts: one for sea salt only, one for marine organic emission