### PR TITLE
refactor setext and its child subroutines

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_extfrc.F90
+++ b/components/eam/src/chemistry/mozart/mo_extfrc.F90
@@ -45,6 +45,7 @@ module mo_extfrc
 
 contains
 
+!==========================================================================
   subroutine extfrc_inti( extfrc_specifier, extfrc_type, extfrc_cycle_yr, extfrc_fixed_ymd, extfrc_fixed_tod)
 
     !-----------------------------------------------------------------------
@@ -264,6 +265,7 @@ contains
 
   end subroutine extfrc_inti
 
+!==========================================================================
   subroutine extfrc_timestep_init( pbuf2d, state )
     !-----------------------------------------------------------------------
     !       ... check serial case for time span
@@ -290,6 +292,7 @@ contains
 
   end subroutine extfrc_timestep_init
 
+!==========================================================================
   subroutine extfrc_set( lchnk, zint, frcing, ncol )
 
     !--------------------------------------------------------
@@ -303,51 +306,53 @@ contains
     !--------------------------------------------------------
     integer,  intent(in)    :: ncol                  ! columns in chunk
     integer,  intent(in)    :: lchnk                 ! chunk index
-    real(r8), intent(in)    :: zint(ncol, pverp)                  ! interface geopot above surface (km)
-    real(r8), intent(inout) :: frcing(ncol,pver,extcnt)   ! insitu forcings (molec/cm^3/s)
+    real(r8), intent(in)    :: zint(ncol, pverp)     ! interface geopot above surface [km]
+    real(r8), intent(inout) :: frcing(ncol,pver,extcnt)   ! insitu forcings [molec/cm^3/s]
 
     !--------------------------------------------------------
     !	... local variables
     !--------------------------------------------------------
-    integer  ::  i, m, n
+    integer  ::  mm, nn
     character(len=16) :: xfcname
     real(r8) :: frcing_col(1:ncol)
-    integer  :: k, isec
+    integer  :: kk, isec
     real(r8),parameter :: km_to_cm = 1.e5_r8
 
     if( extfrc_cnt < 1 .or. extcnt < 1 ) then
        return
-    end if
+    endif
 
     !--------------------------------------------------------
     !	... set non-zero forcings
     !--------------------------------------------------------
-    src_loop : do m = 1,extfrc_cnt
+    src_loop : do mm = 1,extfrc_cnt
 
-      n = forcings(m)%frc_ndx
+      nn = forcings(mm)%frc_ndx
 
-       frcing(:ncol,:,n) = 0._r8
-       do isec = 1,forcings(m)%nsectors
-          if (forcings(m)%file%alt_data) then
-             frcing(:ncol,:,n) = frcing(:ncol,:,n) + forcings(m)%fields(isec)%data(:ncol,pver:1:-1,lchnk)
+       frcing(:ncol,:,nn) = 0._r8
+       do isec = 1,forcings(mm)%nsectors
+          if (forcings(mm)%file%alt_data) then
+             frcing(:ncol,:,nn) = frcing(:ncol,:,nn) + &
+                                forcings(mm)%fields(isec)%data(:ncol,pver:1:-1,lchnk)
           else
-             frcing(:ncol,:,n) = frcing(:ncol,:,n) + forcings(m)%fields(isec)%data(:ncol,:,lchnk)
+             frcing(:ncol,:,nn) = frcing(:ncol,:,nn) + &
+                                forcings(mm)%fields(isec)%data(:ncol,:,lchnk)
           endif
        enddo
-
-       xfcname = trim(forcings(m)%species)//'_XFRC'
-       call outfld( xfcname, frcing(:ncol,:,n), ncol, lchnk )
+       xfcname = trim(forcings(mm)%species)//'_XFRC'
+       call outfld( xfcname, frcing(:ncol,:,nn), ncol, lchnk )
 
        frcing_col(:ncol) = 0._r8
-       do k = 1,pver
-          frcing_col(:ncol) = frcing_col(:ncol) + frcing(:ncol,k,n)*(zint(:ncol,k)-zint(:ncol,k+1))*km_to_cm
+       do kk = 1,pver
+          frcing_col(:ncol) = frcing_col(:ncol) + &
+                        frcing(:ncol,kk,nn)*(zint(:ncol,kk)-zint(:ncol,kk+1))*km_to_cm
        enddo
-       xfcname = trim(forcings(m)%species)//'_CLXF'
+       xfcname = trim(forcings(mm)%species)//'_CLXF'
        call outfld( xfcname, frcing_col(:ncol), ncol, lchnk )
 
-    end do src_loop
+    enddo src_loop
 
   end subroutine extfrc_set
 
-
+!==========================================================================
 end module mo_extfrc

--- a/components/eam/src/chemistry/mozart/mo_extfrc.F90
+++ b/components/eam/src/chemistry/mozart/mo_extfrc.F90
@@ -293,7 +293,7 @@ contains
   end subroutine extfrc_timestep_init
 
 !==========================================================================
-  subroutine extfrc_set( lchnk, zint, frcing, ncol )
+  subroutine extfrc_set( lchnk, zint, ncol, frcing )
 
     !--------------------------------------------------------
     !	... form the external forcing
@@ -307,7 +307,7 @@ contains
     integer,  intent(in)    :: ncol                  ! columns in chunk
     integer,  intent(in)    :: lchnk                 ! chunk index
     real(r8), intent(in)    :: zint(ncol, pverp)     ! interface geopot above surface [km]
-    real(r8), intent(inout) :: frcing(ncol,pver,extcnt)   ! insitu forcings [molec/cm^3/s]
+    real(r8), intent(out)   :: frcing(ncol,pver,extcnt)   ! insitu forcings [molec/cm^3/s]
 
     !--------------------------------------------------------
     !	... local variables
@@ -317,6 +317,8 @@ contains
     real(r8) :: frcing_col(1:ncol)
     integer  :: kk, isec
     real(r8),parameter :: km_to_cm = 1.e5_r8
+
+    frcing(:,:,:) = 0._r8
 
     if( extfrc_cnt < 1 .or. extcnt < 1 ) then
        return

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -696,9 +696,8 @@ contains
     !-----------------------------------------------------------------------
     !        ... Compute the extraneous frcing at time = t(n+1)
     !-----------------------------------------------------------------------      
-    call setext( extfrc, zint, zintr, cldtop, &
-                 zmid, lchnk, tfld, o2mmr, ommr, &
-                 pmid, mbar, rlats, calday, ncol, rlons, pbuf )
+    call setext( extfrc,            & ! out
+                 lchnk, ncol, zintr ) ! in
 
     do m = 1,extcnt
        if( m /= synoz_ndx ) then

--- a/components/eam/src/chemistry/mozart/mo_setext.F90
+++ b/components/eam/src/chemistry/mozart/mo_setext.F90
@@ -132,12 +132,11 @@ contains
     real(r8)    :: spe_nox(ncol,pver)        ! Solar Proton Event NO production
     real(r8)    :: spe_hox(ncol,pver)        ! Solar Proton Event HOx production
 
-    extfrc(:,:,:) = 0._r8
-
     !--------------------------------------------------------
     !     ... set frcing from datasets
     !--------------------------------------------------------
-    call extfrc_set( lchnk, zint_rel, extfrc, ncol )
+    call extfrc_set( lchnk, zint_rel, ncol, & ! in
+                     extfrc ) ! out
     
     !--------------------------------------------------------
     !     ... set nox production from lighting

--- a/components/eam/src/chemistry/mozart/mo_setext.F90
+++ b/components/eam/src/chemistry/mozart/mo_setext.F90
@@ -67,9 +67,8 @@ contains
   end subroutine setext_inti
 
 !==============================================================================
-  subroutine setext( extfrc, zint_abs, zint_rel, cldtop, &
-       zmid, lchnk, tfld, o2mmr, ommr, &
-       pmid, mbar, rlats, calday, ncol, rlons, pbuf )
+  subroutine setext( extfrc,              & ! out
+                     lchnk, ncol, zint    ) ! in
     !--------------------------------------------------------
     !     ... for this latitude slice:
     !         - form the production from datasets
@@ -81,19 +80,8 @@ contains
     use cam_history,  only : outfld
     use shr_kind_mod, only : r8 => shr_kind_r8
     use ppgrid,       only : pver, pcols
-    use mo_airplane,  only : airpl_set
     use chem_mods,    only : extcnt
-    use mo_lightning, only : prod_no
-
     use mo_extfrc,    only : extfrc_set
-    use chem_mods,    only : extcnt
-    use tracer_srcs,  only : num_tracer_srcs, tracer_src_flds, get_srcs_data
-    use mo_chem_utls, only : get_extfrc_ndx
-    use mo_synoz,     only : po3
-
-    use mo_aurora,      only : aurora
-    use mo_solarproton, only : spe_prod 
-    use physics_buffer, only : physics_buffer_desc
 
     implicit none
 
@@ -103,39 +91,19 @@ contains
     !--------------------------------------------------------
     integer,  intent(in)  ::   lchnk                       ! chunk id
     integer,  intent(in)  ::   ncol                        ! columns in chunk
-    real(r8), intent(in)  ::   zint_abs(ncol,pver+1)           ! interface geopot height ( km )
-    real(r8), intent(in)  ::   zint_rel(ncol,pver+1)           ! interface geopot height ( km )
-    real(r8), intent(in)  ::   cldtop(ncol)                ! cloud top index
+    real(r8), intent(in)  ::   zint(ncol,pver+1)           ! interface geopot height [km]
     real(r8), intent(out) ::   extfrc(ncol,pver,extcnt)    ! the "extraneous" forcing
-
-    real(r8), intent(in)  ::   calday                      ! calendar day of year
-    real(r8), intent(in)  ::   rlats(ncol)                 ! column latitudes (radians)
-    real(r8), intent(in)  ::   rlons(ncol)                 ! column longitudes (radians)
-    real(r8), intent(in)  ::   zmid(ncol,pver)             ! midpoint geopot height ( km )
-    real(r8), intent(in)  ::   pmid(pcols,pver)            ! midpoint pressure (Pa)
-    real(r8), intent(in)  ::   tfld(pcols,pver)            ! midpoint temperature (K)
-    real(r8), intent(in)  ::   mbar(ncol,pver)             ! mean molecular mass (g/mole)
-    real(r8), intent(in)  ::   o2mmr(ncol,pver)            ! o2 concentration (kg/kg)
-    real(r8), intent(in)  ::   ommr(ncol,pver)             ! o concentration (kg/kg)
-
-    type(physics_buffer_desc),pointer :: pbuf(:)
 
     !--------------------------------------------------------
     !     ... local variables
     !--------------------------------------------------------
-    integer :: i, k, k1, kk, cldind, ii, jj, nlev
-    real(r8) :: srcs_offline( ncol, pver )
-    integer :: ndx
-
+    ! variables for output. in current MAM4 they are not calculated and are assigned zero
     real(r8), dimension(ncol,pver) :: no_lgt, no_air, co_air
-
-    real(r8)    :: spe_nox(ncol,pver)        ! Solar Proton Event NO production
-    real(r8)    :: spe_hox(ncol,pver)        ! Solar Proton Event HOx production
 
     !--------------------------------------------------------
     !     ... set frcing from datasets
     !--------------------------------------------------------
-    call extfrc_set( lchnk, zint_rel, ncol, & ! in
+    call extfrc_set( lchnk, zint, ncol, & ! in
                      extfrc ) ! out
     
     !--------------------------------------------------------

--- a/components/eam/src/chemistry/mozart/mo_setext.F90
+++ b/components/eam/src/chemistry/mozart/mo_setext.F90
@@ -127,7 +127,7 @@ contains
     real(r8) :: srcs_offline( ncol, pver )
     integer :: ndx
 
-    real(r8), dimension(ncol,pver) :: no_lgt
+    real(r8), dimension(ncol,pver) :: no_lgt, no_air, co_air
 
     real(r8)    :: spe_nox(ncol,pver)        ! Solar Proton Event NO production
     real(r8)    :: spe_hox(ncol,pver)        ! Solar Proton Event HOx production
@@ -148,8 +148,13 @@ contains
     no_lgt(:,:) = 0._r8
     call outfld( 'NO_Lightning', no_lgt(:ncol,:), ncol, lchnk )
 
-    call airpl_set( lchnk, ncol, no_ndx, co_ndx, xno_ndx, cldtop, zint_abs, extfrc)
-
+    ! FORTRAN refactor: in the subroutine airpl_set, has_airpl_src is false,
+    ! the subroutine only has two outfld calls that output zero
+    ! remove the subroutine call and move out the zero outfld
+    no_air(:,:) = 0._r8
+    co_air(:,:) = 0._r8
+    call outfld( 'NO_Aircraft',  no_air(:ncol,:), ncol, lchnk )
+    call outfld( 'CO_Aircraft',  co_air(:ncol,:), ncol, lchnk )
 
   end subroutine setext
 

--- a/components/eam/src/chemistry/mozart/mo_setext.F90
+++ b/components/eam/src/chemistry/mozart/mo_setext.F90
@@ -66,6 +66,7 @@ contains
 
   end subroutine setext_inti
 
+!==============================================================================
   subroutine setext( extfrc, zint_abs, zint_rel, cldtop, &
        zmid, lchnk, tfld, o2mmr, ommr, &
        pmid, mbar, rlats, calday, ncol, rlons, pbuf )
@@ -133,8 +134,6 @@ contains
 
     extfrc(:,:,:) = 0._r8
 
-    no_lgt(:,:) = 0._r8
-
     !--------------------------------------------------------
     !     ... set frcing from datasets
     !--------------------------------------------------------
@@ -143,101 +142,14 @@ contains
     !--------------------------------------------------------
     !     ... set nox production from lighting
     !         note: from ground to cloud top production is c shaped
+    !
+    ! FORTRAN refactor: nox is not included in current MAM4
+    ! the related code are removed but outfld is kept for BFB testing
     !--------------------------------------------------------
-    if ( no_ndx > 0 ) then
-       do i = 1,ncol
-          cldind = nint( cldtop(i) )
-          if( cldind < pver .and. cldind > 0  ) then
-             extfrc(i,cldind:pver,no_ndx) = extfrc(i,cldind:pver,no_ndx) &
-                  + prod_no(i,cldind:pver,lchnk)
-             no_lgt(i,cldind:pver) = prod_no(i,cldind:pver,lchnk)
-          end if
-       end do
-    endif
-    if ( xno_ndx > 0 ) then
-       do i = 1,ncol
-          cldind = nint( cldtop(i) )
-          if( cldind < pver .and. cldind > 0  ) then
-             extfrc(i,cldind:pver,xno_ndx) = extfrc(i,cldind:pver,xno_ndx) &
-                  + prod_no(i,cldind:pver,lchnk)
-          end if
-       end do
-    endif
-
+    no_lgt(:,:) = 0._r8
     call outfld( 'NO_Lightning', no_lgt(:ncol,:), ncol, lchnk )
 
     call airpl_set( lchnk, ncol, no_ndx, co_ndx, xno_ndx, cldtop, zint_abs, extfrc)
-
-    !---------------------------------------------------------------------
-    ! 	... synoz production
-    !---------------------------------------------------------------------
-    if( synoz_ndx > 0 ) then
-       do k = 1,pver
-          extfrc(:ncol,k,synoz_ndx) = extfrc(:ncol,k,synoz_ndx) + po3(:ncol,k,lchnk)
-       end do
-    end if
-
-    do i = 1,num_tracer_srcs
-
-       ndx =  get_extfrc_ndx( tracer_src_flds(i) )
-       call get_srcs_data( tracer_src_flds(i), srcs_offline,  ncol, lchnk, pbuf )
-       do k = 1,pver
-          extfrc(:ncol,k,ndx) = extfrc(:ncol,k,ndx) + srcs_offline(:ncol,k)
-       enddo
-
-    enddo
-
-
-    if ( has_ions ) then
-       !---------------------------------------------------------------------
-       !     ... set ion auroral production
-       !---------------------------------------------------------------------
-
-       call aurora( tfld, o2mmr, ommr, mbar, rlats, &
-            extfrc(:,:,o2p_ndx), extfrc(:,:,op_ndx), extfrc(:,:,n2p_ndx), extfrc(:,:,np_ndx), pmid, &
-            lchnk, calday, ncol, rlons, pbuf )
-       !---------------------------------------------------------------------
-       !     ... set n(2d) and n(4s) auroral production
-       !         Stan Solomon HAO
-       !         include production of N by secondary auroral hot electrons (e_s*):
-       !         this is not a "real" reaction; instead, the production is parameterized in terms
-       !         of the production rate of N2+ by primary electrons, QN2P (which is in the model),
-       !         as follows:
-       !---------------------------------------------------------------------
-       do k = 1,pver
-          extfrc(:,k,n2d_ndx) = 1.57_r8*.6_r8*extfrc(:,k,n2p_ndx)
-          extfrc(:,k,n_ndx) = 1.57_r8*.4_r8*extfrc(:,k,n2p_ndx)
-       end do
-       !---------------------------------------------------------------------
-       !     ... set electron auroral production
-       !---------------------------------------------------------------------
-       do k = 1,pver
-          extfrc(:,k,e_ndx) = extfrc(:,k,op_ndx) + extfrc(:,k,o2p_ndx) &
-               + extfrc(:,k,np_ndx) + extfrc(:,k,n2p_ndx)
-       end do
-       !---------------------------------------------------------------------
-       !     ... set SPE NOx and HOx production
-       !     Jackman et al., JGR, 2005 
-       !     production of 1.25 Nitrogen atoms/ion pair with branching ratios 
-       !     of 0.55 N(4S) and 0.7 N(2D).
-       !---------------------------------------------------------------------
-       call spe_prod( spe_nox, spe_hox, pmid, zmid, lchnk, ncol)
-
-       call outfld( 'N2D_SPE', 0.7_r8*spe_nox,  ncol, lchnk ) ! N(2D) produciton (molec/cm3/s)
-       call outfld( 'N4S_SPE',0.55_r8*spe_nox,  ncol, lchnk ) ! N(4S) produciton (molec/cm3/s)
-       call outfld( 'OH_SPE' ,        spe_hox,  ncol, lchnk ) ! HOX produciton (molec/cm3/s)
-
-       extfrc(:ncol,:pver,n2d_ndx) = extfrc(:ncol,:pver,n2d_ndx) +  0.7_r8*spe_nox(:ncol,:pver)
-       extfrc(:ncol,:pver,  n_ndx) = extfrc(:ncol,:pver,  n_ndx) + 0.55_r8*spe_nox(:ncol,:pver)
-       extfrc(:ncol,:pver, oh_ndx) = extfrc(:ncol,:pver, oh_ndx)         + spe_hox(:ncol,:pver)
-
-       call outfld( 'P_Op',  extfrc(:,:,op_ndx), ncol, lchnk )
-       call outfld( 'P_O2p', extfrc(:,:,o2p_ndx), ncol, lchnk )
-       call outfld( 'P_Np',  extfrc(:,:,np_ndx), ncol, lchnk )
-       call outfld( 'P_N2p', extfrc(:,:,n2p_ndx), ncol, lchnk )
-       call outfld( 'P_IONS',extfrc(:,:,n2d_ndx), ncol, lchnk )
-
-    endif
 
 
   end subroutine setext


### PR DESCRIPTION
remove unused code and variables. remove the call of `airpl_set` which only output zero variables and put the outfld call out of the subroutine. 