### PR TITLE
Minor cleanup of a couple of routines

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_chemini.F90
+++ b/components/eam/src/chemistry/mozart/mo_chemini.F90
@@ -78,7 +78,6 @@ contains
     use mo_synoz,          only : synoz_inti
     use mo_chem_utls,      only : get_spc_ndx
     use mo_airglow,        only : init_airglow
-    use mo_mean_mass,      only : init_mean_mass
     use mo_mass_xforms,    only : init_mass_xforms
     use mo_strato_rates,   only : init_strato_rates
     use mo_cph,            only : init_cph
@@ -140,7 +139,6 @@ contains
 
     call gas_phase_chemdr_inti(chem_name)
 
-    call init_mean_mass
     call init_mass_xforms
 
     call setinv_inti()

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -230,7 +230,7 @@ contains
     use physics_buffer,    only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
     use infnan,            only : nan, assignment(=)
     use rate_diags,        only : rate_diags_calc
-    use mo_mass_xforms,    only : mmr2vmr, vmr2mmr, h2o_to_vmr, mmr2vmri
+    use mo_mass_xforms,    only : mmr2vmr, vmr2mmr, h2o_to_vmr
     use orbit,             only : zenith
 !
 ! LINOZ
@@ -454,7 +454,8 @@ contains
     !-----------------------------------------------------------------------      
     !        ... Set atmosphere mean mass
     !-----------------------------------------------------------------------      
-    call set_mean_mass( ncol, mbar )
+    call set_mean_mass( ncol, & !in
+         mbar ) !out
 
     !-----------------------------------------------------------------------      
     !        ... Xform from mmr to vmr

--- a/components/eam/src/chemistry/mozart/mo_mass_xforms.F90
+++ b/components/eam/src/chemistry/mozart/mo_mass_xforms.F90
@@ -5,7 +5,7 @@ module mo_mass_xforms
 
 
   private
-  public :: mmr2vmr, mmr2vmri, vmr2mmr, h2o_to_vmr, init_mass_xforms
+  public :: mmr2vmr, vmr2mmr, h2o_to_vmr, init_mass_xforms
   save
 
   real(r8) :: adv_mass_h2o = 18._r8
@@ -52,41 +52,11 @@ contains
 
   end subroutine mmr2vmr
 
-  subroutine mmr2vmri( mmr, vmr, mbar, mi, ncol )
-    !-----------------------------------------------------------------
-    !	... Xfrom from mass to volume mixing ratio
-    !-----------------------------------------------------------------
-
-    implicit none
-
-    !-----------------------------------------------------------------
-    !	... Dummy args
-    !-----------------------------------------------------------------
-    integer, intent(in)     :: ncol
-    real(r8), intent(in)    :: mi
-    real(r8), intent(in)    :: mbar(:,:)
-    real(r8), intent(in)    :: mmr(:,:)
-    real(r8), intent(inout) :: vmr(:,:)
-
-    !-----------------------------------------------------------------
-    !	... Local variables
-    !-----------------------------------------------------------------
-    integer  :: k
-    real(r8) :: rmi
-
-    rmi = 1._r8/mi
-    do k = 1,pver
-       vmr(:ncol,k) = mbar(:ncol,k) * mmr(:ncol,k) * rmi
-    end do
-
-  end subroutine mmr2vmri
-
   subroutine vmr2mmr( vmr, mmr, mbar, ncol )
     !-----------------------------------------------------------------
     !	... Xfrom from volume to mass mixing ratio
     !-----------------------------------------------------------------
 
-    use m_spc_id
     use chem_mods, only : adv_mass, gas_pcnst
 
     implicit none
@@ -121,8 +91,6 @@ contains
     !-----------------------------------------------------------------------
     !     ... Transform water vapor from mass to volumetric mixing ratio
     !-----------------------------------------------------------------------
-
-    use chem_mods, only : adv_mass
 
     implicit none
 

--- a/components/eam/src/chemistry/mozart/mo_mean_mass.F90
+++ b/components/eam/src/chemistry/mozart/mo_mean_mass.F90
@@ -4,25 +4,11 @@ module mo_mean_mass
   implicit none
 
   private
-  public :: set_mean_mass, init_mean_mass
-
-  integer :: id_o2, id_o, id_h, id_n
+  public :: set_mean_mass
 
 contains
-
-  subroutine init_mean_mass
-    use mo_chem_utls, only : get_spc_ndx
-
-    implicit none
-
-    id_o2 = get_spc_ndx('O2')
-    id_o  = get_spc_ndx('O')
-    id_h  = get_spc_ndx('H')
-    id_n  = get_spc_ndx('N')
-
-  endsubroutine init_mean_mass
-
-  subroutine set_mean_mass( ncol, mbar )
+  subroutine set_mean_mass( ncol, &! in
+       mbar ) !out
     !-----------------------------------------------------------------
     !        ... Set the invariant densities (molecules/cm**3)
     !-----------------------------------------------------------------


### PR DESCRIPTION
I have cleaned up some routines. These include:
1. Removal of unused or no impact `init_mean_mass` and `mmr2vmri` subroutines
2. Removal of unused variables of use statements.