### PR TITLE
Refactor of tropopause_find and dependencies

### DIFF
--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1427,7 +1427,7 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! get tropopause level
 !-----------------------------------------------------------------------
-    call tropopause_find(state, tropLev, primary=TROP_ALG_HYBSTOB, backup=TROP_ALG_CLIMATE)
+    call tropopause_find(lchnk,ncol,state%pmid,state%pint,state%t,state%zm,state%zi,tropLev,primary=TROP_ALG_HYBSTOB,backup=TROP_ALG_CLIMATE)
 
     tim_ndx = pbuf_old_tim_idx()
     call pbuf_get_field(pbuf, ndx_pblh,       pblh)

--- a/components/eam/src/chemistry/utils/prescribed_volcaero.F90
+++ b/components/eam/src/chemistry/utils/prescribed_volcaero.F90
@@ -320,7 +320,8 @@ end subroutine prescribed_volcaero_readnl
           call pbuf_get_field(pbuf_chnk, fields(1)%pbuf_ndx, data)
           data(:ncol,:) = to_mmr(:ncol,:) * data(:ncol,:) ! mmr
           
-          call tropopause_find(state(c), tropLev, primary=TROP_ALG_TWMO, backup=TROP_ALG_CLIMATE)
+          call tropopause_find(state(c)%lchnk,ncol,state(c)%pmid,state(c)%pint,state(c)%t,state(c)%zm,state(c)%zi,  &
+                     tropLev, primary=TROP_ALG_TWMO, backup=TROP_ALG_CLIMATE)
           do i = 1,ncol
              do k = 1,pver
                 ! set to zero below tropopause

--- a/components/eam/src/physics/cam/aer_rad_props.F90
+++ b/components/eam/src/physics/cam/aer_rad_props.F90
@@ -244,7 +244,7 @@ subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6
 
       !Find tropopause as extinction should be applied only above tropopause
       !trop_level has value for tropopause for each column
-      call tropopause_find(state, trop_level)
+      call tropopause_find(lchnk,ncol,state%pmid,state%pint,state%t,state%zm,state%zi,trop_level)
       !Quit if tropopause is not found
       if (any(trop_level(1:ncol) == -1)) then
          do icol = 1, ncol
@@ -457,7 +457,7 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
 
       !Find tropopause
       !trop_level has value for tropopause for each column
-      call tropopause_find(state, trop_level)
+      call tropopause_find(lchnk,ncol,state%pmid,state%pint,state%t,state%zm,state%zi,trop_level)
       !Quit if tropopause is not found
       if (any(trop_level(1:ncol) == -1)) then
          do icol = 1, ncol

--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -1169,23 +1169,15 @@ contains
     ! Dispatch the request to the appropriate routine.
     ! BJG:  if output_all can be assumed to be always false, then analytic, stobie, wmo options can be removed below, as well as other sections
     select case(algorithm)
-      case(TROP_ALG_ANALYTIC)
-        call tropopause_analytic(pstate, tropLev, tropP, tropT, tropZ)
 
       case(TROP_ALG_CLIMATE)
         call tropopause_climate(pstate, tropLev, tropP, tropT, tropZ)
-
-      case(TROP_ALG_STOBIE)
-        call tropopause_stobie(pstate, tropLev, tropP, tropT, tropZ)
 
       case(TROP_ALG_HYBSTOB)
         call tropopause_hybridstobie(pstate, tropLev, tropP, tropT, tropZ)
 
       case(TROP_ALG_TWMO)
         call tropopause_twmo(pstate, tropLev, tropP, tropT, tropZ)
-
-      case(TROP_ALG_WMO)
-        call tropopause_wmo(pstate, tropLev, tropP, tropT, tropZ)
 
       case(TROP_ALG_CPP)
         call tropopause_cpp(pstate, tropLev, tropP, tropT, tropZ)
@@ -1419,31 +1411,6 @@ contains
     call outfld('TROPF_PD',  tropPdf(:ncol, :), ncol, lchnk)
     call outfld('TROPF_FD',  tropFound(:ncol),  ncol, lchnk)
     
-    ! If requested, do all of the algorithms.
-    if (output_all) then
-    
-      do alg = 2, TROP_NALG
-    
-        ! Find the tropopause using just the analytic algorithm.
-        call tropopause_find(pstate, tropLev, tropP=tropP, tropT=tropT, tropZ=tropZ, primary=alg, backup=TROP_ALG_NONE)
-  
-        tropPdf(:,:) = 0._r8
-        tropFound(:) = 0._r8
-      
-        do i = 1, ncol
-          if (tropLev(i) /= NOTFOUND) then
-            tropPdf(i, tropLev(i)) = 1._r8
-            tropFound(i) = 1._r8
-          end if
-        end do
-  
-        call outfld('TROP' // TROP_LETTER(alg) // '_P',   tropP(:ncol),      ncol, lchnk)
-        call outfld('TROP' // TROP_LETTER(alg) // '_T',   tropT(:ncol),      ncol, lchnk)
-        call outfld('TROP' // TROP_LETTER(alg) // '_Z',   tropZ(:ncol),      ncol, lchnk)
-        call outfld('TROP' // TROP_LETTER(alg) // '_PD',  tropPdf(:ncol, :), ncol, lchnk)
-        call outfld('TROP' // TROP_LETTER(alg) // '_FD',  tropFound(:ncol),  ncol, lchnk)
-      end do
-    end if
     
     return
   end subroutine tropopause_output

--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -72,9 +72,9 @@ module tropopause
   character(len=256)    :: tropopause_climo_file = 'trop_climo'      ! absolute filepath of climatology file
 
   ! These variables are used to store the climatology data.
-  integer, parameter :: days_in_year_real = 365._r8
-  integer, parameter :: months_in_year = 12
-  integer, parameter :: first_month = 1
+  real(r8), parameter :: days_in_year_real = 365._r8
+  integer, parameter  :: months_in_year = 12
+  integer, parameter  :: first_month = 1
   real(r8)              :: days(months_in_year)                      ! days in the climatology
   real(r8), pointer     :: tropp_p_loc(:,:,:)                        ! climatological tropopause pressures
 
@@ -1182,7 +1182,7 @@ contains
     ncol  = pstate%ncol
 
     ! Find the tropopause using the default algorithm backed by the climatology.
-    call tropopause_find(lchnk,ncol,pstate%pint,pstate%pmid,pstate%t,pstate%zm,pstate%zi,  & ! in
+    call tropopause_find(lchnk,ncol,pstate%pmid,pstate%pint,pstate%t,pstate%zm,pstate%zi,  & ! in
          tropLev,tropP=tropP,tropT=tropT,tropZ=tropZ)   ! out / optional out
     
     tropPdf(:,:) = 0._r8
@@ -1205,7 +1205,7 @@ contains
     
     
     ! Find the tropopause using just the primary algorithm.
-    call tropopause_find(lchnk,ncol,pstate%pint,pstate%pmid,pstate%t,pstate%zm,pstate%zi,  & ! in
+    call tropopause_find(lchnk,ncol,pstate%pmid,pstate%pint,pstate%t,pstate%zm,pstate%zi,  & ! in
          tropLev,tropP=tropP,tropT=tropT,tropZ=tropZ,   &  ! out / optional out
          backup=TROP_ALG_NONE)  ! optional in
 
@@ -1229,7 +1229,7 @@ contains
     call outfld('TROPP_FD',  tropFound(:ncol),  ncol, lchnk)
     
     ! Find the tropopause using just the cold point algorithm.
-    call tropopause_find(lchnk,ncol,pstate%pint,pstate%pmid,pstate%t,pstate%zm,pstate%zi,  & ! in
+    call tropopause_find(lchnk,ncol,pstate%pmid,pstate%pint,pstate%t,pstate%zm,pstate%zi,  & ! in
          tropLev,tropP=tropP,tropT=tropT,tropZ=tropZ,  &  ! out / optional out
          primary=TROP_ALG_CPP,backup=TROP_ALG_NONE) ! optional in
 

--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -590,12 +590,8 @@ contains
     level = size(temp1d)
     pmk= .5_r8 * (pmid1d(level-1)**cnst_kap+pmid1d(level)**cnst_kap)
     pm = pmk**(1/cnst_kap)               
-    call get_dtdz(pm,pmk,pmid1d(level-1),pmid1d(level),temp1d(level-1),temp1d(level),dtdz,tm)
-!BJG    a1 = (temp1d(level-1)-temp1d(level))/(pmid1d(level-1)**cnst_kap-pmid1d(level)**cnst_kap)
-!BJG    b1 = temp1d(level)-(a1*pmid1d(level)**cnst_kap)
-!BJG    tm = a1 * pmk + b1               
-!BJG    dtdp = a1 * cnst_kap * (pm**cnst_ka1)
-!BJG    dtdz = cnst_faktor*dtdp*pm/tm
+    call get_dtdz(pm,pmk,pmid1d(level-1),pmid1d(level),temp1d(level-1),temp1d(level),  & ! in
+         dtdz,tm)  ! inout
 
     main_loop: do kk=level-1,2,-1
       pm0 = pm
@@ -605,12 +601,8 @@ contains
       ! dt/dz
       pmk= .5_r8 * (pmid1d(kk-1)**cnst_kap+pmid1d(kk)**cnst_kap)
       pm = pmk**(1/cnst_kap)               
-      call get_dtdz(pm,pmk,pmid1d(kk-1),pmid1d(kk),temp1d(kk-1),temp1d(kk),dtdz,tm)
-!BJG      a1 = (temp1d(kk-1)-temp1d(kk))/(pmid1d(kk-1)**cnst_kap-pmid1d(kk)**cnst_kap)
-!BJG      b1 = temp1d(kk)-(a1*pmid1d(kk)**cnst_kap)
-!BJG      tm = a1 * pmk + b1
-!BJG      dtdp = a1 * cnst_kap * (pm**cnst_ka1)
-!BJG      dtdz = cnst_faktor*dtdp*pm/tm
+      call get_dtdz(pm,pmk,pmid1d(kk-1),pmid1d(kk),temp1d(kk-1),temp1d(kk),   & ! in 
+           dtdz,tm)  ! inout
       ! dt/dz valid?
       if (dtdz<=gam)   cycle main_loop    ! no, dt/dz < -2 K/km
       if (pm>plimu)   cycle main_loop    ! no, too low
@@ -640,13 +632,8 @@ contains
         if(pm2>ptph) cycle in_loop            ! doesn't happen
         if(pm2<p2km) exit in_loop             ! ptropo is valid
 
-        call get_dtdz(pm2,pmk2,pmid1d(jj-1),pmid1d(jj),temp1d(jj-1),temp1d(jj),dtdz2,tm2)
-!BJG        a2 = (temp1d(jj-1)-temp1d(jj))                     ! a
-!BJG        a2 = a2/(pmid1d(jj-1)**cnst_kap-pmid1d(jj)**cnst_kap)
-!BJG        b2 = temp1d(jj)-(a2*pmid1d(jj)**cnst_kap)          ! b
-!BJG        tm2 = a2 * pmk2 + b2                     ! T mean
-!BJG        dtdp2 = a2 * cnst_kap * (pm2**(cnst_kap-1))  ! dt/dp
-!BJG        dtdz2 = cnst_faktor*dtdp2*pm2/tm2
+        call get_dtdz(pm2,pmk2,pmid1d(jj-1),pmid1d(jj),temp1d(jj-1),temp1d(jj),  & ! in
+             dtdz2,tm2) ! out
         asum = asum+dtdz2
         icount = icount+1
         aquer = asum/float(icount)               ! dt/dz mean
@@ -662,7 +649,8 @@ contains
     
   end subroutine twmo
   
-  subroutine get_dtdz(pm,pmk,pmid1d_up,pmid1d_down,temp1d_up,temp1d_down,dtdz,tm)
+  subroutine get_dtdz(pm,pmk,pmid1d_up,pmid1d_down,temp1d_up,temp1d_down,    & ! in
+             dtdz,tm)   ! inout
 
     implicit none
 

--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -173,43 +173,9 @@ contains
          'Troposphere boundary calculated in chemistry' )
 
     ! If requested, be prepared to output results from all of the methods.
-    if (output_all) then
-      call addfld('TROPA_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (analytic)', flag_xyfill=.True.)
-      call addfld('TROPA_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (analytic)', flag_xyfill=.True.)
-      call addfld('TROPA_Z',           horiz_only,    'A',  'm', 'Tropopause Height (analytic)', flag_xyfill=.True.)
-      call addfld('TROPA_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (analytic)')
-      call addfld('TROPA_FD', horiz_only,    'A', 'probability', 'Tropopause Found (analytic)')
-
-      call addfld('TROPC_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (climatology)', flag_xyfill=.True.)
-      call addfld('TROPC_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (climatology)', flag_xyfill=.True.)
-      call addfld('TROPC_Z',           horiz_only,    'A',  'm', 'Tropopause Height (climatology)', flag_xyfill=.True.)
-      call addfld('TROPC_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (climatology)')
-      call addfld('TROPC_FD', horiz_only,    'A', 'probability', 'Tropopause Found (climatology)')
-
-      call addfld('TROPS_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (stobie)', flag_xyfill=.True.)
-      call addfld('TROPS_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (stobie)', flag_xyfill=.True.)
-      call addfld('TROPS_Z',           horiz_only,    'A',  'm', 'Tropopause Height (stobie)', flag_xyfill=.True.)
-      call addfld('TROPS_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (stobie)')
-      call addfld('TROPS_FD', horiz_only,    'A', 'probability', 'Tropopause Found (stobie)')
-
-      call addfld('TROPT_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (twmo)', flag_xyfill=.True.)
-      call addfld('TROPT_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (twmo)', flag_xyfill=.True.)
-      call addfld('TROPT_Z',           horiz_only,    'A',  'm', 'Tropopause Height (twmo)', flag_xyfill=.True.)
-      call addfld('TROPT_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (twmo)')
-      call addfld('TROPT_FD', horiz_only,    'A', 'probability', 'Tropopause Found (twmo)')
-
-      call addfld('TROPW_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (WMO)', flag_xyfill=.True.)
-      call addfld('TROPW_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (WMO)', flag_xyfill=.True.)
-      call addfld('TROPW_Z',           horiz_only,    'A',  'm', 'Tropopause Height (WMO)', flag_xyfill=.True.)
-      call addfld('TROPW_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (WMO)')
-      call addfld('TROPW_FD', horiz_only,    'A', 'probability', 'Tropopause Found (WMO)')
-
-      call addfld('TROPH_P',          horiz_only,    'A',  'Pa', 'Tropopause Pressure (Hybrid Stobie)', flag_xyfill=.True.)
-      call addfld('TROPH_T',           horiz_only,    'A',  'K', 'Tropopause Temperature (Hybrid Stobie)', flag_xyfill=.True.)
-      call addfld('TROPH_Z',           horiz_only,    'A',  'm', 'Tropopause Height (Hybrid Stobie)', flag_xyfill=.True.)
-      call addfld('TROPH_PD', (/ 'lev' /), 'A', 'probability', 'Tropopause Distribution (Hybrid Stobie)')
-      call addfld('TROPH_FD', horiz_only,    'A', 'probability', 'Tropopause Found (Hybrid Stobie)')
-     end if
+    ! BJG:  since output_all can be assumed to be always false, below section is removed
+!BJG    if (output_all) then
+!BJG     end if
 
     call add_default('TROP_P', 1, ' ')
     call add_default('TROP_T', 1, ' ')
@@ -370,57 +336,10 @@ contains
 
   ! This analytic expression closely matches the mean tropopause determined
   ! by the NCEP reanalysis and has been used by the radiation code.
-  subroutine tropopause_analytic(pstate, tropLev, tropP, tropT, tropZ)
+! BJG below removed since not called in our tests
+!BJG  subroutine tropopause_analytic(pstate, tropLev, tropP, tropT, tropZ)
 
-    implicit none
-
-    type(physics_state), intent(in)     :: pstate
-    integer,            intent(inout)   :: tropLev(pcols)             ! tropopause level index   
-    real(r8), optional, intent(inout)   :: tropP(pcols)               ! tropopause pressure (Pa)  
-    real(r8), optional, intent(inout)   :: tropT(pcols)               ! tropopause temperature (K)
-    real(r8), optional, intent(inout)   :: tropZ(pcols)               ! tropopause height (m)
-    
-    ! Local Variables
-    integer       :: i
-    integer       :: k
-    integer       :: ncol                     ! number of columns in the chunk
-    integer       :: lchnk                    ! chunk identifier
-    real(r8)      :: tP                       ! tropopause pressure (Pa)
- 
-    ! Information about the chunk.  
-    lchnk = pstate%lchnk
-    ncol  = pstate%ncol
-
-    ! Iterate over all of the columns.
-    do i = 1, ncol
-     
-      ! Skip column in which the tropopause has already been found.
-      if (tropLev(i) == NOTFOUND) then
-      
-        ! Calculate the pressure of the tropopause.
-        tP = (25000.0_r8 - 15000.0_r8 * (cos(pstate%lat(i)))**2)
-      
-        ! Find the level that contains the tropopause.
-        do k = pver, 2, -1
-          if (tP >= pstate%pint(i, k)) then
-            tropLev(i) = k
-            exit
-          end if
-        end do
-        
-        ! Return the optional outputs
-        if (present(tropP)) tropP(i) = tP
-        
-        if (present(tropT)) then
-          tropT(i) = tropopause_interpolateT(pstate, i, tropLev(i), tP)
-        end if
-
-        if (present(tropZ)) then
-          tropZ(i) = tropopause_interpolateZ(pstate, i, tropLev(i), tP)
-        end if
-      end if
-    end do
-  end subroutine tropopause_analytic
+!BJG  end subroutine tropopause_analytic
 
 
   ! Read the tropopause pressure in from a file containging a climatology. The
@@ -624,78 +543,10 @@ contains
   ! This routine originates with Stobie at NASA Goddard, but does not have a
   ! known reference. It was supplied by Philip Cameron-Smith of LLNL.
   !
-  subroutine tropopause_stobie(pstate, tropLev, tropP, tropT, tropZ)
+!BJG below not called so removed
+!BJG  subroutine tropopause_stobie(pstate, tropLev, tropP, tropT, tropZ)
 
-    implicit none
-
-    type(physics_state), intent(in)     :: pstate 
-    integer,            intent(inout)   :: tropLev(pcols)             ! tropopause level index   
-    real(r8), optional, intent(inout)   :: tropP(pcols)               ! tropopause pressure (Pa)  
-    real(r8), optional, intent(inout)   :: tropT(pcols)               ! tropopause temperature (K)
-    real(r8), optional, intent(inout)   :: tropZ(pcols)               ! tropopause height (m)
-    
-    ! Local Variables
-    integer       :: i
-    integer       :: k
-    integer       :: ncol                     ! number of columns in the chunk
-    integer       :: lchnk                    ! chunk identifier
-    integer       :: tLev                     ! tropopause level
-    real(r8)      :: tP                       ! tropopause pressure (Pa)
-    real(r8)      :: stobie(pver)             ! stobie weighted temperature
-    real(r8)      :: sTrop                    ! stobie value at the tropopause
- 
-    ! Information about the chunk.  
-    lchnk = pstate%lchnk
-    ncol  = pstate%ncol
-
-    ! Iterate over all of the columns.
-    do i = 1, ncol
-     
-      ! Skip column in which the tropopause has already been found.
-      if (tropLev(i) == NOTFOUND) then
-      
-        ! Caclulate a pressure weighted temperature.
-        stobie(:) = ALPHA * pstate%t(i,:) - log10(pstate%pmid(i, :))
-
-        ! Search from the bottom up, looking for the first minimum.
-        tLev  = -1
-  
-        do k = pver-1, 1, -1
-    
-          if (pstate%pmid(i, k) <= 4000._r8) then
-            exit
-          end if
-    
-          if (pstate%pmid(i, k) >= 55000._r8) then
-            cycle
-          end if
-          
-          if ((tLev == -1) .or. (stobie(k) < sTrop)) then
-            tLev  = k
-            tP    = pstate%pmid(i, k)
-            sTrop = stobie(k)
-          end if
-        end do
-        
-        if (tLev /= -1) then
-          tropLev(i) = tLev
-        
-          ! Return the optional outputs
-          if (present(tropP)) tropP(i) = tP
-          
-          if (present(tropT)) then
-            tropT(i) = tropopause_interpolateT(pstate, i, tropLev(i), tP)
-          end if
-
-          if (present(tropZ)) then
-            tropZ(i) = tropopause_interpolateZ(pstate, i, tropLev(i), tP)
-          end if
-        end if
-      end if
-    end do
-    
-    return
-  end subroutine tropopause_stobie
+!BJG  end subroutine tropopause_stobie
 
 
   ! This routine is an implementation of Reichler et al. [2003] done by
@@ -889,94 +740,10 @@ contains
   ! NOTE: This code was modeled after the code in mo_tropopause; however, the
   ! requirement that dt be greater than 0 was removed and the check to make
   ! sure that the lapse rate is maintained for 2 km was added.
-  subroutine tropopause_wmo(pstate, tropLev, tropP, tropT, tropZ)
+! BJG below not used, so deleted
+!BJG  subroutine tropopause_wmo(pstate, tropLev, tropP, tropT, tropZ)
 
-    implicit none
-
-    type(physics_state), intent(in)    :: pstate 
-    integer,            intent(inout)  :: tropLev(pcols)            ! tropopause level index   
-    real(r8), optional, intent(inout)  :: tropP(pcols)              ! tropopause pressure (Pa)   
-    real(r8), optional, intent(inout)  :: tropT(pcols)              ! tropopause temperature (K)
-    real(r8), optional, intent(inout)  :: tropZ(pcols)              ! tropopause height (m)
-
-    ! Local Variables 
-    real(r8), parameter    :: ztrop_low   = 5000._r8        ! lowest tropopause level allowed (m)
-    real(r8), parameter    :: ztrop_high  = 20000._r8       ! highest tropopause level allowed (m)
-    real(r8), parameter    :: max_dtdz    = 0.002_r8        ! max dt/dz for tropopause level (K/m)
-    real(r8), parameter    :: min_trop_dz = 2000._r8        ! min tropopause thickness (m)
-
-    integer                 :: i
-    integer                 :: k
-    integer                 :: k2
-    integer                 :: ncol                         ! number of columns in the chunk
-    integer                 :: lchnk                        ! chunk identifier
-    real(r8)                :: tP                           ! tropopause pressure (Pa)
-    real(r8)                :: dt
-
-    ! Information about the chunk.  
-    lchnk = pstate%lchnk
-    ncol  = pstate%ncol
-
-    ! Iterate over all of the columns.
-    do i = 1, ncol
-     
-      ! Skip column in which the tropopause has already been found.
-      if (tropLev(i) == NOTFOUND) then
-
-        kloop: do k = pver-1, 2, -1
-         
-          ! Skip levels below the minimum and stop if nothing is found
-          ! before the maximum.
-          if (pstate%zm(i, k) < ztrop_low) then
-            cycle kloop
-          else if (pstate%zm(i, k) > ztrop_high) then
-            exit kloop
-          end if
-          
-          ! Compare the actual lapse rate to the threshold
-          dt = pstate%t(i, k) - pstate%t(i, k-1)
-            
-          if (dt <= (max_dtdz * (pstate%zm(i, k-1) - pstate%zm(i, k)))) then
-            
-            ! Make sure that the lapse rate stays below the threshold for the
-            ! specified range.
-            k2loop: do k2 = k-1, 2, -1
-              if ((pstate%zm(i, k2) - pstate%zm(i, k)) >= min_trop_dz) then
-                tP = pstate%pmid(i, k)
-                tropLev(i) = k
-                exit k2loop
-              end if
-              
-              dt = pstate%t(i, k) - pstate%t(i, k2)
-              if (dt > (max_dtdz * (pstate%zm(i, k2) - pstate%zm(i, k)))) then
-                exit k2loop
-              end if
-           end do k2loop
-
-           if (tropLev(i) == NOTFOUND) then
-              cycle kloop
-           else 
-
-              ! Return the optional outputs
-              if (present(tropP)) tropP(i) = tP
-              
-              if (present(tropT)) then
-                tropT(i) = tropopause_interpolateT(pstate, i, tropLev(i), tP)
-              end if
-  
-              if (present(tropZ)) then
-                tropZ(i) = tropopause_interpolateZ(pstate, i, tropLev(i), tP)
-              end if
-
-              exit kloop
-            end if
-          end if
-        end do kloop
-      end if
-    end do
-    
-    return
-  end subroutine tropopause_wmo
+!BJG  end subroutine tropopause_wmo
   
   ! This routine searches for the cold point tropopause, and uses a parabolic
   ! fit of the coldest point and two adjacent points to interpolate the cold point


### PR DESCRIPTION
1)  Remove code for 'TROP_ALG_ANALYTIC', 'TROP_ALG_STOBIE', and 'TROP_ALG_WMO' tropopause finding options in physics/cam/tropopause.F90, since these options are never invoked externally, and 'output_all' flag is set to .false.
2)  Remove other subroutines and code in tropopause.F90 never invoked.
3)  Extract fields from 'state' structure, and pass these to tropopause_find subroutine, instead of state structure itself.
4)  Clean code (add units, remove single character variable names, insert in / out designations).